### PR TITLE
Use public via Meta.parse for Julia 1.10 compatibility

### DIFF
--- a/ChunkCodecCore/Project.toml
+++ b/ChunkCodecCore/Project.toml
@@ -4,4 +4,4 @@ authors = ["nhz2 <nhz2@cornell.edu>"]
 version = "0.4.0"
 
 [compat]
-julia = "1.11"
+julia = "1.10"

--- a/ChunkCodecCore/src/ChunkCodecCore.jl
+++ b/ChunkCodecCore/src/ChunkCodecCore.jl
@@ -2,36 +2,38 @@ module ChunkCodecCore
 
 export decode, encode
 
-public Codec
-public EncodeOptions
-public DecodeOptions
+include("public.jl")
 
-public DecodingError
-public DecodedSizeError
+@public Codec
+@public EncodeOptions
+@public DecodeOptions
 
-public decode_options
+@public DecodingError
+@public DecodedSizeError
 
-public decoded_size_range
-public encode_bound
-public try_encode!
+@public decode_options
 
-public try_find_decoded_size
-public try_decode!
+@public decoded_size_range
+@public encode_bound
+@public try_encode!
 
-public check_in_range
-public check_contiguous
+@public try_find_decoded_size
+@public try_decode!
 
-public can_concatenate
-public is_thread_safe
-public try_resize_decode!
+@public check_in_range
+@public check_contiguous
 
-public NoopCodec
-public NoopEncodeOptions
-public NoopDecodeOptions
+@public can_concatenate
+@public is_thread_safe
+@public try_resize_decode!
 
-public ShuffleCodec
-public ShuffleEncodeOptions
-public ShuffleDecodeOptions
+@public NoopCodec
+@public NoopEncodeOptions
+@public NoopDecodeOptions
+
+@public ShuffleCodec
+@public ShuffleEncodeOptions
+@public ShuffleDecodeOptions
 
 include("types.jl")
 include("errors.jl")

--- a/ChunkCodecCore/src/public.jl
+++ b/ChunkCodecCore/src/public.jl
@@ -1,0 +1,26 @@
+@static if VERSION ≥ v"1.11"
+    macro public(s::Symbol)
+        return esc(Expr(:public, s))
+    end
+    macro public(e::Expr)
+        return esc(Expr(:public, e.args...))
+    end
+else
+    macro public(e) end
+end
+
+@doc("""
+    @public foo, [bar...]
+
+A simplified public macro for private use by ChunkCodecs
+
+In Julia 1.10 or earlier, the macro is only an annotation
+and performs no operation.
+
+In Julia 1.11 and later, the macro uses the `public` keyword.
+
+This macro is meant to be simple only deals with symbols or
+tuple expressions. It does not handle macro calls or do any
+validation. Validate effectiveness in testing via
+`Base.ispublic`.
+""", :(ChunkCodecCore.@public))

--- a/ChunkCodecCore/src/public.jl
+++ b/ChunkCodecCore/src/public.jl
@@ -1,4 +1,4 @@
-@static if VERSION ≥ v"1.11"
+@static if VERSION ≥ v"1.11.0-DEV.469"
     macro public(s::Symbol)
         return esc(Expr(:public, s))
     end

--- a/ChunkCodecCore/test/runtests.jl
+++ b/ChunkCodecCore/test/runtests.jl
@@ -88,3 +88,41 @@ end
     @test_throws DecodedSizeError(Int64(-1), nothing) decode(d, ones(UInt8, Int64(100)); max_size=Int64(-1))
     @test_throws DecodedSizeError(typemin(Int64), nothing) decode(d, ones(UInt8, Int64(100)); max_size=typemin(Int128))
 end
+@testset "public" begin
+    @static if VERSION ≥ v"1.11"
+        for sym in (
+            :Codec,
+            :EncodeOptions,
+            :DecodeOptions,
+
+            :DecodingError,
+            :DecodedSizeError,
+
+            :decode_options,
+
+            :decoded_size_range,
+            :encode_bound,
+            :try_encode!,
+
+            :try_find_decoded_size,
+            :try_decode!,
+
+            :check_in_range,
+            :check_contiguous,
+
+            :can_concatenate,
+            :is_thread_safe,
+            :try_resize_decode!,
+
+            :NoopCodec,
+            :NoopEncodeOptions,
+            :NoopDecodeOptions,
+
+            :ShuffleCodec,
+            :ShuffleEncodeOptions,
+            :ShuffleDecodeOptions
+        )
+            @test Base.ispublic(ChunkCodecCore, sym)
+        end
+    end
+end

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -10,4 +10,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChunkCodecCore = "0.4"
 Test = "1"
-julia = "1.11"
+julia = "1.10"

--- a/ChunkCodecs/Project.toml
+++ b/ChunkCodecs/Project.toml
@@ -20,7 +20,7 @@ ChunkCodecLibLz4 = "0.1"
 ChunkCodecLibSnappy = "0.1"
 ChunkCodecLibZlib = "0.1"
 ChunkCodecLibZstd = "0.1"
-julia = "1.11"
+julia = "1.10"
 
 [sources]
 ChunkCodecCore = {path = "../ChunkCodecCore"}

--- a/LibBlosc/Project.toml
+++ b/LibBlosc/Project.toml
@@ -10,4 +10,4 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 [compat]
 Blosc_jll = "1"
 ChunkCodecCore = "0.4"
-julia = "1.11"
+julia = "1.10"

--- a/LibBlosc/src/ChunkCodecLibBlosc.jl
+++ b/LibBlosc/src/ChunkCodecLibBlosc.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_in_range,
     check_contiguous,
-    DecodingError
+    DecodingError,
+    @public
 import ChunkCodecCore:
     decode_options,
     try_decode!,
@@ -22,7 +23,7 @@ export BloscCodec,
     BloscDecodeOptions,
     BloscDecodingError
 
-public is_compressor_valid, compcode, compname
+@public is_compressor_valid, compcode, compname
 
 # reexport ChunkCodecCore
 using ChunkCodecCore: ChunkCodecCore, encode, decode

--- a/LibBlosc/test/runtests.jl
+++ b/LibBlosc/test/runtests.jl
@@ -77,3 +77,10 @@ end
     c[end-5] = 0x40
     @test_throws BloscDecodingError decode(BloscDecodeOptions(), c)
 end
+@testset "public" begin
+    @static if VERSION ≥ v"1.11"
+        for sym in (:is_compressor_valid, :compcode, :compname)
+            @test Base.ispublic(ChunkCodecLibBlosc, sym)
+        end
+    end
+end

--- a/LibBzip2/Project.toml
+++ b/LibBzip2/Project.toml
@@ -10,4 +10,4 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 [compat]
 Bzip2_jll = "1"
 ChunkCodecCore = "0.4"
-julia = "1.11"
+julia = "1.10"

--- a/LibLz4/Project.toml
+++ b/LibLz4/Project.toml
@@ -10,4 +10,4 @@ Lz4_jll = "5ced341a-0733-55b8-9ab6-a4889d929147"
 [compat]
 ChunkCodecCore = "0.4"
 Lz4_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibSnappy/Project.toml
+++ b/LibSnappy/Project.toml
@@ -10,4 +10,4 @@ snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 [compat]
 ChunkCodecCore = "0.4"
 snappy_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibZlib/Project.toml
+++ b/LibZlib/Project.toml
@@ -10,4 +10,4 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 [compat]
 ChunkCodecCore = "0.4"
 Zlib_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibZstd/Project.toml
+++ b/LibZstd/Project.toml
@@ -10,4 +10,4 @@ Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 [compat]
 ChunkCodecCore = "0.4"
 Zstd_jll = "1.5.6"
-julia = "1.11"
+julia = "1.10"

--- a/LibZstd/src/ChunkCodecLibZstd.jl
+++ b/LibZstd/src/ChunkCodecLibZstd.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_contiguous,
     check_in_range,
-    DecodingError
+    DecodingError,
+    @public
 
 import ChunkCodecCore:
     can_concatenate,
@@ -25,7 +26,7 @@ export ZstdCodec,
     ZstdDecodeOptions,
     ZstdDecodingError
 
-public ZSTD_minCLevel,
+@public ZSTD_minCLevel,
     ZSTD_maxCLevel,
     ZSTD_defaultCLevel,
     ZSTD_versionNumber,

--- a/LibZstd/test/runtests.jl
+++ b/LibZstd/test/runtests.jl
@@ -97,3 +97,19 @@ end
         "ZstdDecodingError: ",
     )
 end
+@testset "public" begin
+    @static if VERSION ≥ v"1.11"
+        for sym in (
+            :ZSTD_minCLevel,
+            :ZSTD_maxCLevel,
+            :ZSTD_defaultCLevel,
+            :ZSTD_versionNumber,
+            :ZSTD_isError,
+            :ZSTD_bounds,
+            :ZSTD_cParam_getBounds,
+            :ZSTD_dParam_getBounds
+        )
+            @test Base.ispublic(ChunkCodecLibZstd, sym)
+        end
+    end
+end


### PR DESCRIPTION
- **Remove simple `@public` macro**
- **Support early development versions of Julia 1.11**
