### PR TITLE
[ChunkCodecCore] Add inplace decode

### DIFF
--- a/ChunkCodecCore/src/ChunkCodecCore.jl
+++ b/ChunkCodecCore/src/ChunkCodecCore.jl
@@ -11,6 +11,7 @@ if VERSION >= v"1.11.0-DEV.469"
 
             DecodingError,
             DecodedSizeError,
+            decode!,
 
             decode_options,
 

--- a/ChunkCodecCore/src/errors.jl
+++ b/ChunkCodecCore/src/errors.jl
@@ -10,6 +10,7 @@ abstract type DecodingError <: Exception end
     DecodedSizeError(max_size, decoded_size)
 
 Unable to decode the data because the decoded size is larger than `max_size`
+or smaller than expected.
 If the decoded size is unknown `decoded_size` is `nothing`.
 """
 struct DecodedSizeError <: Exception
@@ -21,6 +22,11 @@ function Base.showerror(io::IO, err::DecodedSizeError)
     print(io, "DecodedSizeError: ")
     if isnothing(err.decoded_size)
         print(io, "decoded size is greater than max size: ")
+        print(io, err.max_size)
+    elseif err.decoded_size < err.max_size
+        print(io, "decoded size: ")
+        print(io, err.decoded_size)
+        print(io, " is less than expected size: ")
         print(io, err.max_size)
     else
         print(io, "decoded size: ")

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -68,6 +68,32 @@ function decode(
 end
 
 """
+    decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}) -> dst
+
+Decode the input data `src` into `dst` using decoder `d`.
+`d` must implement [`try_decode!`](@ref).
+
+Throw a [`DecodedSizeError`](@ref) if the decoded output size is not exactly `length(dst)`.
+
+Throw a [`DecodingError`](@ref) if decoding fails because the input data is not valid.
+
+Otherwise throw an error.
+
+Precondition: `dst` and `src` do not overlap in memory.
+
+See also [`decode`](@ref) and [`encode`](@ref)
+"""
+function decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8})
+    expected_size::Int64 = length(dst)
+    n = try_decode!(d, dst, src)
+    if n != expected_size
+        throw(DecodedSizeError(expected_size, n))
+    else
+        dst
+    end
+end
+
+"""
     decode_options(::Codec)::DecodeOptions
 
 Return the default decode options for the codec.


### PR DESCRIPTION
This PR adds the `decode!` function.

This function is similar to `try_decode!` but will throw a `DecodedSizeError` if the decoded output size doesn't match the length of `dst`.