### PR TITLE
[ChunkCodecCore] Allow values in `decoded_size_range` to saturate

### DIFF
--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Allow values in `decoded_size_range` to saturate `encode_bound` to `typemax(Int64)`. [#64](https://github.com/JuliaIO/ChunkCodecs.jl/pull/64)
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)
 
 ## [v0.5.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v0.5.1) - 2025-07-06

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -114,9 +114,6 @@ can_concatenate(::Codec) = false
 
 Return the range of allowed `src` sizes for encoding.
 
-[`encode_bound`](@ref) on any value in the returned range must be in
-`0:typemax(Int64)-1`.
-
 See also [`encode_bound`](@ref)
 """
 function decoded_size_range end

--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Allow values in `decoded_size_range` to saturate `encode_bound` to `typemax(Int64)`. [#64](https://github.com/JuliaIO/ChunkCodecs.jl/pull/64)
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)
 
 ## [v0.1.4](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.4) - 2025-07-06

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -57,11 +57,10 @@ function test_encoder_decoder(e, d; trials=100)
     @test step(srange) > 0
     @test first(srange) ≥ 0
     @test last(srange) != typemax(Int64) # avoid length overflow
-    # typemax(Int64) is reserved as a sentinel
-    @test encode_bound(e, last(srange)) < typemax(Int64)
-    @test encode_bound(e, last(srange)) < encode_bound(e, typemax(Int64))
+    # typemax(Int64) is reserved for saturation
+    @test encode_bound(e, typemax(Int64)) == typemax(Int64)
 
-    for s in [first(srange):step(srange):min(last(srange), 1000); rand(srange, 10000); last(srange)]
+    for s in [first(srange):step(srange):min(last(srange), 1000); rand(srange, 10000); last(srange); typemax(Int64)-1; typemax(Int64);]
         @test encode_bound(e, s) isa Int64
         @test encode_bound(e, s) ≥ s
     end


### PR DESCRIPTION
This PR loosens the requirement that values in `decoded_size_range` never saturate `encode_bound` to `typemax(Int64)`.

Before this change, the last value in `decoded_size_range` was required not to saturate `encode_bound`.

However, this requirement wasn't being used anywhere, and since `encode_bound` already has the requirement:
> On the domain of `0:typemax(Int64)` this function must not error and must be monotonically increasing.

It is fast to find the last size before saturation using a binary search.

This means that encoders with no practical limits on decoded size can have `decoded_size_range` return `Int64(0):Int64(1):typemax(Int64)-Int64(1)` instead of needing to find the point before `encode_bound` saturates.