### PR TITLE
Update imagecodecs to 2025.8.2

### DIFF
--- a/test/CondaPkg.toml
+++ b/test/CondaPkg.toml
@@ -1,4 +1,4 @@
 [pip.deps]
-imagecodecs = "==2025.3.30"
+imagecodecs = "==2025.8.2"
 hdf5plugin = "==5.1.0"
 h5py = "==3.13.0"

--- a/test/imagecodecs-compat.jl
+++ b/test/imagecodecs-compat.jl
@@ -33,8 +33,7 @@ codecs = [
     (ChunkCodecLibBrotli.BrotliEncodeOptions(;quality=9),   ("brotli",   (;)), 50),
     (ChunkCodecLibBzip2.BZ2EncodeOptions(),     ("bz2",     (;)), 50),
     (ChunkCodecLibLz4.LZ4BlockEncodeOptions(),  ("lz4",     (;header=false)), 1000),
-    # TODO enable this test when https://github.com/cgohlke/imagecodecs/pull/127 is merged
-    # (ChunkCodecLibLz4.LZ4HDF5EncodeOptions(),   ("lz4h5",     (;)), 1000),
+    (ChunkCodecLibLz4.LZ4HDF5EncodeOptions(),   ("lz4h5",     (;)), 1000),
     (ChunkCodecLibLz4.LZ4NumcodecsEncodeOptions(),   ("lz4",     (;header=true)), 1000),
     (ChunkCodecLibLz4.LZ4FrameEncodeOptions(),  ("lz4f",    (;)), 1000),
     (ChunkCodecLibSnappy.SnappyEncodeOptions(),  ("snappy",    (;)), 1000),


### PR DESCRIPTION
Fixes #48 now that https://github.com/cgohlke/imagecodecs/pull/127 has been released.