### PR TITLE
Support Julia 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,19 +82,21 @@ jobs:
           - windows-latest
           - macos-latest
         version:
+          - '1.6'
           - 'pre'
         arch:
           - 'default'
-        include:
+          - 'x86'
+        exclude:
+          - os: macos-latest
+            version: 'x86'
           - os: ubuntu-latest
             version: '1.6'
-            arch: 'default'
-          - os: ubuntu-latest
-            version: 'pre'
             arch: 'x86'
           - os: windows-latest
-            version: 'pre'
-            arch: 'x86'
+            version: '1.6'
+          - os: macos-latest
+            version: '1.6'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         # e.g. ['package1', 'package2'] if both package folders contains changes
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
         version:
-          - '1.9'
+          - '1.6'
           - '1'
           - 'pre'
         os:
@@ -92,15 +92,15 @@ jobs:
           - os: macos-latest
             arch: 'x86'
           - os: macos-latest
-            version: '1.9'
+            version: '1.6'
           - os: macos-latest
             version: 'pre'
           - os: windows-latest
-            version: '1.9'
+            version: '1.6'
           - os: windows-latest
             version: 'pre'
           - os: ubuntu-latest
-            version: '1.9'
+            version: '1.6'
             arch: 'x86'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,30 +77,23 @@ jobs:
         # Parse JSON array containing names of all filters matching any of changed files
         # e.g. ['package1', 'package2'] if both package folders contains changes
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
-        version:
-          - '1.6'
-          - '1'
-          - 'pre'
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        version:
+          - 'pre'
         arch:
           - 'default'
-          - 'x86'
-        exclude:
-          - os: macos-latest
-            arch: 'x86'
-          - os: macos-latest
-            version: '1.6'
-          - os: macos-latest
-            version: 'pre'
-          - os: windows-latest
-            version: '1.6'
-          - os: windows-latest
-            version: 'pre'
+        include:
           - os: ubuntu-latest
             version: '1.6'
+            arch: 'default'
+          - os: ubuntu-latest
+            version: 'pre'
+            arch: 'x86'
+          - os: windows-latest
+            version: 'pre'
             arch: 'x86'
     steps:
       - uses: actions/checkout@v4
@@ -114,19 +107,29 @@ jobs:
       - name: Run the tests
         shell: julia --color=yes {0}
         run: |
-          using Pkg
-          using TOML
-          Pkg.Registry.update()
-          Pkg.activate(;temp=true)
-          # force it to use this PR's version of the package
-          ENV["JULIA_PKG_DEVDIR"]= mktempdir()
-          Pkg.develop(unique([
-            (;path="${{ matrix.package }}"),
-            (;path="ChunkCodecCore"),
-            (;path="ChunkCodecTests"),
-          ]))
-          Pkg.update()
-          Pkg.test(TOML.parsefile("${{ matrix.package }}/Project.toml")["name"]; coverage=true, allow_reresolve=false)
+          @static if VERSION >= v"1.12"
+            using Pkg
+            Pkg.Registry.update()
+            Pkg.activate("${{ matrix.package }}")
+            Pkg.test()
+          else
+            using Pkg
+            using TOML
+            Pkg.Registry.update()
+            Pkg.activate(;temp=true)
+            # force it to use this PR's version of the package
+            ENV["JULIA_PKG_DEVDIR"]= mktempdir()
+            Pkg.develop(unique([
+              (;path="${{ matrix.package }}"),
+              (;path="ChunkCodecCore"),
+              (;path="ChunkCodecTests"),
+              # Hack to test Bitshuffle on Julia 1.6 before new LibZstd/LibLz4 are released
+              (;path="LibZstd"),
+              (;path="LibLz4"),
+            ]))
+            Pkg.update()
+            Pkg.test(TOML.parsefile("${{ matrix.package }}/Project.toml")["name"]; coverage=true)
+          end
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: ${{matrix.package}}/src

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,7 +89,7 @@ jobs:
           - 'x86'
         exclude:
           - os: macos-latest
-            version: 'x86'
+            arch: 'x86'
           - os: ubuntu-latest
             version: '1.6'
             arch: 'x86'

--- a/Bitshuffle/Project.toml
+++ b/Bitshuffle/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
 ChunkCodecCore = "0.5.1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.5.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v0.5.2) - 2025-07-28
 
 - Allow values in `decoded_size_range` to saturate `encode_bound` to `typemax(Int64)`. [#64](https://github.com/JuliaIO/ChunkCodecs.jl/pull/64)

--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.5.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v0.5.2) - 2025-07-28
 

--- a/ChunkCodecCore/Project.toml
+++ b/ChunkCodecCore/Project.toml
@@ -4,7 +4,7 @@ authors = ["nhz2 <nhz2@cornell.edu>"]
 version = "0.5.2"
 
 [compat]
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -223,7 +223,9 @@ function try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{U
         while true
             ds = try_decode!(d, dst, src)::Union{Nothing, Int64}
             if isnothing(ds)
-                @something grow_dst!(dst, max_size) return nothing
+                if isnothing(grow_dst!(dst, max_size))
+                    return nothing
+                end
             else
                 @assert ds ∈ 0:length(dst)
                 return ds

--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.1.5](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.5) - 2025-07-28
 

--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.1.5](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.5) - 2025-07-28
 
 - Allow values in `decoded_size_range` to saturate `encode_bound` to `typemax(Int64)`. [#64](https://github.com/JuliaIO/ChunkCodecs.jl/pull/64)

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -10,4 +10,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChunkCodecCore = "0.5.1"
 Test = "1"
-julia = "1.9"
+julia = "1.6"

--- a/LibAec/CHANGELOG.md
+++ b/LibAec/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.1.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibAec-v0.1.2) - 2025-07-28
 

--- a/LibAec/CHANGELOG.md
+++ b/LibAec/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.1.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibAec-v0.1.2) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibAec/Project.toml
+++ b/LibAec/Project.toml
@@ -10,7 +10,7 @@ libaec_jll = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
 [compat]
 ChunkCodecCore = "0.5.1"
 libaec_jll = "1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibBlosc/CHANGELOG.md
+++ b/LibBlosc/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBlosc-v0.2.1) - 2025-07-28
 

--- a/LibBlosc/CHANGELOG.md
+++ b/LibBlosc/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBlosc-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibBlosc/Project.toml
+++ b/LibBlosc/Project.toml
@@ -10,7 +10,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 [compat]
 Blosc_jll = "1"
 ChunkCodecCore = "0.5"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibBlosc/test/Project.toml
+++ b/LibBlosc/test/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ChunkCodecLibBlosc = "c6a955be-ab7f-4fbb-b38f-caf93db6b928"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
+ChunkCodecLibBlosc = "c6a955be-ab7f-4fbb-b38f-caf93db6b928"
 ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/LibBrotli/CHANGELOG.md
+++ b/LibBrotli/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBrotli-v0.2.1) - 2025-07-28
 

--- a/LibBrotli/CHANGELOG.md
+++ b/LibBrotli/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBrotli-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibBrotli/Project.toml
+++ b/LibBrotli/Project.toml
@@ -10,7 +10,7 @@ brotli_jll = "4611771a-a7d2-5e23-8d00-b1becdba1aae"
 [compat]
 ChunkCodecCore = "0.5"
 brotli_jll = "1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibBrotli/src/decode.jl
+++ b/LibBrotli/src/decode.jl
@@ -94,7 +94,10 @@ function try_resize_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, 
                 end
                 if result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT
                     @assert iszero(dst_left)
-                    local next_size = @something grow_dst!(dst, max_size) return nothing
+                    local next_size = grow_dst!(dst, max_size)
+                    if isnothing(next_size)
+                        return nothing
+                    end
                     dst_left += next_size - dst_size
                     dst_size = next_size
                     @assert dst_left > 0

--- a/LibBzip2/CHANGELOG.md
+++ b/LibBzip2/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBzip2-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibBzip2/CHANGELOG.md
+++ b/LibBzip2/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBzip2-v0.2.1) - 2025-07-28
 

--- a/LibBzip2/Project.toml
+++ b/LibBzip2/Project.toml
@@ -10,7 +10,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 [compat]
 Bzip2_jll = "1"
 ChunkCodecCore = "0.5"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibBzip2/src/decode.jl
+++ b/LibBzip2/src/decode.jl
@@ -102,7 +102,10 @@ function try_resize_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src
                             # there must be progress
                             @assert stream.avail_in < start_avail_in || stream.avail_out < start_avail_out
                         elseif iszero(dst_left) # needs more output
-                            local next_size = @something grow_dst!(dst, max_size) return nothing
+                            local next_size = grow_dst!(dst, max_size)
+                            if isnothing(next_size)
+                                return nothing
+                            end
                             dst_left += next_size - dst_size
                             dst_size = next_size
                             @assert dst_left > 0

--- a/LibBzip2/test/Project.toml
+++ b/LibBzip2/test/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ChunkCodecLibBzip2 = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
+ChunkCodecLibBzip2 = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/LibLz4/CHANGELOG.md
+++ b/LibLz4/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibLz4-v0.2.2) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibLz4/CHANGELOG.md
+++ b/LibLz4/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibLz4-v0.2.2) - 2025-07-28
 

--- a/LibLz4/Project.toml
+++ b/LibLz4/Project.toml
@@ -10,7 +10,7 @@ Lz4_jll = "5ced341a-0733-55b8-9ab6-a4889d929147"
 [compat]
 ChunkCodecCore = "0.5"
 Lz4_jll = "1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibLz4/src/decode.jl
+++ b/LibLz4/src/decode.jl
@@ -108,7 +108,10 @@ function try_resize_decode!(d::LZ4FrameDecodeOptions, dst::AbstractVector{UInt8}
                             end
                         else
                             if iszero(dst_left) # needs more output
-                                local next_size = @something grow_dst!(dst, max_size) return nothing
+                                local next_size = grow_dst!(dst, max_size)
+                                if isnothing(next_size)
+                                    return nothing
+                                end
                                 dst_left += next_size - dst_size
                                 dst_size = next_size
                                 @assert dst_left > 0

--- a/LibLz4/src/liblz4.jl
+++ b/LibLz4/src/liblz4.jl
@@ -2,18 +2,18 @@
 # https://github.com/lz4/lz4/blob/v1.10.0/lib/lz4.h
 # https://github.com/lz4/lz4/blob/v1.10.0/lib/lz4hc.h
 
-const LZ4HC_CLEVEL_MIN::Int32      =  2
-const LZ4HC_CLEVEL_DEFAULT::Int32  =  9
-const LZ4HC_CLEVEL_OPT_MIN::Int32  = 10
-const LZ4HC_CLEVEL_MAX::Int32      = 12
+const LZ4HC_CLEVEL_MIN      =  Int32(2)
+const LZ4HC_CLEVEL_DEFAULT  =  Int32(9)
+const LZ4HC_CLEVEL_OPT_MIN  = Int32(10)
+const LZ4HC_CLEVEL_MAX      = Int32(12)
 
 # Note this is in lz4.c but I'm not sure why
 const LZ4_ACCELERATION_MAX = Int32(65537)
 
 const LZ4_MAX_INPUT_SIZE = Int64(0x7E000000)
 
-const LZ4_MIN_CLEVEL::Int32 = -(LZ4_ACCELERATION_MAX - Int32(1))
-const LZ4_MAX_CLEVEL::Int32 = LZ4HC_CLEVEL_MAX
+const LZ4_MIN_CLEVEL = Int32(-(LZ4_ACCELERATION_MAX - Int32(1)))
+const LZ4_MAX_CLEVEL = Int32(LZ4HC_CLEVEL_MAX)
 
 # LZ4_COMPRESSBOUND assuming `src_size` is in 0:LZ4_MAX_INPUT_SIZE
 function unsafe_lz4_compressbound(src_size::Int64)

--- a/LibLz4/test/Project.toml
+++ b/LibLz4/test/Project.toml
@@ -1,8 +1,8 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
-ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 ChunkCodecLibLz4 = "7e9cc85e-5614-42a3-ad86-b78f920b38a5"
+ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"

--- a/LibSnappy/CHANGELOG.md
+++ b/LibSnappy/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibSnappy-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibSnappy/CHANGELOG.md
+++ b/LibSnappy/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibSnappy-v0.2.1) - 2025-07-28
 

--- a/LibSnappy/Project.toml
+++ b/LibSnappy/Project.toml
@@ -10,7 +10,7 @@ snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 [compat]
 ChunkCodecCore = "0.5"
 snappy_jll = "1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibZlib/CHANGELOG.md
+++ b/LibZlib/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZlib-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibZlib/CHANGELOG.md
+++ b/LibZlib/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZlib-v0.2.1) - 2025-07-28
 

--- a/LibZlib/Project.toml
+++ b/LibZlib/Project.toml
@@ -10,7 +10,7 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 [compat]
 ChunkCodecCore = "0.5"
 Zlib_jll = "1"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]

--- a/LibZlib/src/decode.jl
+++ b/LibZlib/src/decode.jl
@@ -148,7 +148,10 @@ function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, sr
                             @assert ret != Z_BUF_ERROR
                             @assert stream.avail_in < start_avail_in || stream.avail_out < start_avail_out
                         elseif iszero(dst_left) # needs more output
-                            local next_size = @something grow_dst!(dst, max_size) return nothing
+                            local next_size = grow_dst!(dst, max_size)
+                            if isnothing(next_size)
+                                return nothing
+                            end
                             dst_left += next_size - dst_size
                             dst_size = next_size
                             @assert dst_left > 0

--- a/LibZlib/test/Project.toml
+++ b/LibZlib/test/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
-ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 ChunkCodecLibZlib = "4c0bbee4-addc-4d73-81a0-b6caacae83c8"
+ChunkCodecTests = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/LibZstd/CHANGELOG.md
+++ b/LibZstd/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZstd-v0.2.1) - 2025-07-28
 
 - Added support for Julia 1.9 [#63](https://github.com/JuliaIO/ChunkCodecs.jl/pull/63)

--- a/LibZstd/CHANGELOG.md
+++ b/LibZstd/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Added support for Julia 1.6 [#67](https://github.com/JuliaIO/ChunkCodecs.jl/pull/67)
+- Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZstd-v0.2.1) - 2025-07-28
 

--- a/LibZstd/Project.toml
+++ b/LibZstd/Project.toml
@@ -10,7 +10,7 @@ Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 [compat]
 ChunkCodecCore = "0.5"
 Zstd_jll = "1.5.6"
-julia = "1.9"
+julia = "1.6"
 
 [workspace]
 projects = ["test"]


### PR DESCRIPTION
This requires removing the use of `@something`, which was added in 1.7

Also, `const` cannot have type annotations.