### PR TITLE
[ChunkCodecCore] BREAKING change the return type to `MaybeSize`

### DIFF
--- a/Bitshuffle/CHANGELOG.md
+++ b/Bitshuffle/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
+
 ## [v0.1.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/Bitshuffle-v0.1.1) - 2025-08-09
 
 ### Added

--- a/Bitshuffle/Project.toml
+++ b/Bitshuffle/Project.toml
@@ -1,13 +1,13 @@
 name = "ChunkCodecBitshuffle"
 uuid = "1d859bbf-6282-4c80-a370-34c59bf7ec11"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.1"
+version = "0.2.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
-ChunkCodecCore = "0.5.1"
+ChunkCodecCore = "0.6"
 julia = "1.6"
 
 [workspace]

--- a/Bitshuffle/src/ChunkCodecBitshuffle.jl
+++ b/Bitshuffle/src/ChunkCodecBitshuffle.jl
@@ -10,6 +10,7 @@ using ChunkCodecCore:
     check_contiguous,
     DecodingError,
     MaybeSize,
+    NOT_SIZE,
     is_size
 import ChunkCodecCore:
     decode_options,
@@ -224,10 +225,10 @@ function try_encode!(e::BShufCodec, dst::AbstractVector{UInt8}, src::AbstractVec
     block_size = e.block_size
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        nothing
+        NOT_SIZE
     else
         apply_blocks!(trans_bit_elem!, src, dst, element_size, block_size)
-        return src_size
+        src_size
     end
 end
 
@@ -283,8 +284,8 @@ end
 
 is_thread_safe(::BShufDecodeOptions) = true
 
-function try_find_decoded_size(::BShufDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
-    MaybeSize(length(src))
+function try_find_decoded_size(::BShufDecodeOptions, src::AbstractVector{UInt8})::Int64
+    length(src)
 end
 
 function try_decode!(d::BShufDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
@@ -297,7 +298,7 @@ function try_decode!(d::BShufDecodeOptions, dst::AbstractVector{UInt8}, src::Abs
         throw(BShufDecodingError("src_size isn't a multiple of element_size"))
     end
     if dst_size < src_size
-        MaybeSize(-src_size)
+        NOT_SIZE
     else
         apply_blocks!(untrans_bit_elem!, src, dst, element_size, block_size)
         src_size

--- a/Bitshuffle/src/compress.jl
+++ b/Bitshuffle/src/compress.jl
@@ -120,7 +120,7 @@ function encode_bound(e::BShufLZEncodeOptions, src_size::Int64)::Int64
     bound
 end
 
-function try_encode!(e::BShufLZEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::BShufLZEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)
@@ -162,15 +162,15 @@ function try_encode!(e::BShufLZEncodeOptions, dst::AbstractVector{UInt8}, src::A
         end
         src_offset = src_size - src_left
         trans_bit_elem!(tmp_buf_bshuf, Int64(0), src, src_offset, elem_size, block_size)
-        compressed_nbytes = try_encode!(
+        maybe_compressed_nbytes = try_encode!(
             e.options,
             @view(dst[end-dst_left+1+4:end]),
             @view(tmp_buf_bshuf[begin:begin+elem_size*block_size-1])
-        )
-        if isnothing(compressed_nbytes)
+        )::MaybeSize
+        if !is_size(maybe_compressed_nbytes)
             return nothing # no space for compressed block
         end
-        @assert !signbit(compressed_nbytes)
+        compressed_nbytes = Int64(maybe_compressed_nbytes)
         store_int32_BE!(dst, dst_size - dst_left, Int32(compressed_nbytes))
         src_left -= block_size*elem_size
         dst_left -= 4 + compressed_nbytes
@@ -227,7 +227,7 @@ end
 
 is_thread_safe(d::BShufLZDecodeOptions) = is_thread_safe(d.options)
 
-function try_find_decoded_size(d::BShufLZDecodeOptions, src::AbstractVector{UInt8})::Int64
+function try_find_decoded_size(d::BShufLZDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     if length(src) < 12
         throw(BShufDecodingError("unexpected end of input"))
     else
@@ -242,10 +242,10 @@ function try_find_decoded_size(d::BShufLZDecodeOptions, src::AbstractVector{UInt
     end
 end
 
-function try_decode!(d::BShufLZDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::BShufLZDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
-    decoded_size = try_find_decoded_size(d, src)
+    decoded_size::Int64 = try_find_decoded_size(d, src)
     src_size::Int64 = length(src)
     dst_size::Int64 = length(dst)
     if decoded_size > dst_size
@@ -294,9 +294,9 @@ function try_decode!(d::BShufLZDecodeOptions, dst::AbstractVector{UInt8}, src::A
             d.options,
             @view(tmp_buf_decode[begin:begin+block_size*elem_size-1]),
             @view(src[end-src_left+1:end-src_left+c_size])
-        )
+        )::MaybeSize
         src_left -= c_size
-        if ret != block_size*elem_size
+        if ret.val != block_size*elem_size
             throw(BShufDecodingError("saved decoded size is not correct"))
         end
         untrans_bit_elem!(dst, dst_offset, tmp_buf_decode, Int64(0), elem_size, block_size)

--- a/Bitshuffle/test/runtests.jl
+++ b/Bitshuffle/test/runtests.jl
@@ -258,7 +258,7 @@ end
     # less than 12 bytes
     @test_throws BShufDecodingError("unexpected end of input") try_find_decoded_size(d, UInt8[])
     @test_throws BShufDecodingError("decoded size is negative") try_find_decoded_size(d, fill(0xFF,12))
-    @test MaybeSize(typemax(Int64)) == try_find_decoded_size(d, [0x7F; fill(0xFF, 11);])
+    @test typemax(Int64) == try_find_decoded_size(d, [0x7F; fill(0xFF, 11);])
     # invalid block size
     @test_throws BShufDecodingError("block size must not be negative") decode(d, [
         reinterpret(UInt8, [hton(Int64(0))]);

--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### BREAKING the return type of `try_encode`, `try_decode`, and `try_resize_decode!` changed to a new `MaybeSize` type [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
+
 ## [v0.5.3](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v0.5.3) - 2025-08-09
 
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)

--- a/ChunkCodecCore/Project.toml
+++ b/ChunkCodecCore/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecCore"
 uuid = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.5.3"
+version = "0.6.0-dev"
 
 [compat]
 julia = "1.6"

--- a/ChunkCodecCore/src/ChunkCodecCore.jl
+++ b/ChunkCodecCore/src/ChunkCodecCore.jl
@@ -9,6 +9,9 @@ if VERSION >= v"1.11.0-DEV.469"
             EncodeOptions,
             DecodeOptions,
 
+            MaybeSize,
+            is_size,
+            NOT_SIZE,
             DecodingError,
             DecodedSizeError,
             decode!,

--- a/ChunkCodecCore/src/errors.jl
+++ b/ChunkCodecCore/src/errors.jl
@@ -14,7 +14,6 @@ If `val ≥ 0` this represents a size, and can be converted back and forth with 
 Otherwise will error when converted to and from `Int64`.
 `-val` is a size hint if not `typemin(Int64)`.
 
-`nothing` can be converted to and from `MaybeSize(typemin(Int64))`
 """
 struct MaybeSize
     val::Int64
@@ -41,16 +40,6 @@ function Base.convert(::Type{MaybeSize}, x::Int64)::MaybeSize
         throw(InexactError(:convert, MaybeSize, x))
     else
         MaybeSize(x)
-    end
-end
-function Base.convert(::Type{MaybeSize}, x::Nothing)::MaybeSize
-    NOT_SIZE
-end
-function Base.convert(::Type{Nothing}, x::MaybeSize)::Nothing
-    if x !== NOT_SIZE
-        throw(InexactError(:convert, Nothing, x))
-    else
-        nothing
     end
 end
 

--- a/ChunkCodecCore/src/errors.jl
+++ b/ChunkCodecCore/src/errors.jl
@@ -26,7 +26,7 @@ const NOT_SIZE = MaybeSize(typemin(Int64))
 function is_size(x::MaybeSize)::Bool
     !signbit(x.val)
 end
-function Int64(x::MaybeSize)
+function Base.Int64(x::MaybeSize)
     if !is_size(x)
         throw(InexactError(:Int64, Int64, x))
     else

--- a/ChunkCodecCore/src/errors.jl
+++ b/ChunkCodecCore/src/errors.jl
@@ -6,6 +6,36 @@ Generic error for data that cannot be decoded.
 abstract type DecodingError <: Exception end
 
 """
+    struct MaybeSize
+        val::Int64
+    end
+
+If `val ≥ 0` this represents a size, and can be converted to `Int64`.
+If `val == typemin(Int64)` this is not a size and will error when.
+Otherwise will error when converted to `Int64`.
+`-val` is a size hint if not `typemin(Int64)`.
+"""
+struct MaybeSize
+    val::Int64
+end
+function is_size(x::MaybeSize)::Bool
+    !signbit(x.val)
+end
+function Int64(x::MaybeSize)::Int64
+    if !is_size(x)
+        throw(InexactError(:Int64, Int64, x))
+    else
+        x.val
+    end
+end
+function Base.convert(::Type{Int64}, x::MaybeSize)::Int64
+    Int64(x)
+end
+
+const NOT_SIZE = MaybeSize(typemin(Int64))
+
+
+"""
     struct DecodedSizeError <: Exception
     DecodedSizeError(max_size, decoded_size)
 
@@ -15,24 +45,33 @@ If the decoded size is unknown `decoded_size` is `nothing`.
 """
 struct DecodedSizeError <: Exception
     max_size::Int64
-    decoded_size::Union{Nothing, Int64}
+    decoded_size::MaybeSize
 end
 
 function Base.showerror(io::IO, err::DecodedSizeError)
     print(io, "DecodedSizeError: ")
-    if isnothing(err.decoded_size)
+    if err.decoded_size == NOT_SIZE
         print(io, "decoded size is greater than max size: ")
         print(io, err.max_size)
-    elseif err.decoded_size < err.max_size
-        print(io, "decoded size: ")
-        print(io, err.decoded_size)
-        print(io, " is less than expected size: ")
+    elseif !is_size(err.decoded_size)
+        print(io, "decoded size is greater than max size: ")
         print(io, err.max_size)
+        print(io, " decoder hints to try with ")
+        print(io, -err.decoded_size.val)
+        print(io, " bytes")
     else
-        print(io, "decoded size: ")
-        print(io, err.decoded_size)
-        print(io, " is greater than max size: ")
-        print(io, err.max_size)
+        decoded_size::Int64 = err.decoded_size
+        if decoded_size < err.max_size
+            print(io, "decoded size: ")
+            print(io, decoded_size)
+            print(io, " is less than expected size: ")
+            print(io, err.max_size)
+        else
+            print(io, "decoded size: ")
+            print(io, decoded_size)
+            print(io, " is greater than max size: ")
+            print(io, err.max_size)
+        end
     end
     nothing
 end

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -169,15 +169,15 @@ Return `true` if the encoder is lossless.
 is_lossless(::Any) = true
 
 """
-    try_find_decoded_size(d, src::AbstractVector{UInt8})::MaybeSize
+    try_find_decoded_size(d, src::AbstractVector{UInt8})::Union{Nothing, Int64}
 
 Try to return the size of the decoded output of `src` using `d`.
 
-If the size cannot be quickly determined, return `NOT_SIZE`.
+If the size cannot be quickly determined, return `nothing`.
 
 If the encoded data is found to be invalid, throw a `DecodingError`.
 
-If a `is_size` size is returned, it must be the exact size of the decoded output.
+If an `Int64` is returned, it must be the exact size of the decoded output.
 If [`try_decode!`](@ref) is called with a `dst` of this size, it must succeed and return the same size, or throw an error.
 """
 function try_find_decoded_size end
@@ -221,8 +221,8 @@ All of `dst` can be written to or used as scratch space by the decoder.
 Only the initial returned number of bytes are valid output.
 """
 function try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
-    maybe_decoded_size = try_find_decoded_size(d, src)::MaybeSize
-    if !is_size(maybe_decoded_size)
+    maybe_decoded_size = try_find_decoded_size(d, src)::Union{Nothing, Int64}
+    if isnothing(maybe_decoded_size)
         while true
             ds = try_decode!(d, dst, src)::MaybeSize
             if !is_size(ds)

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -190,7 +190,7 @@ Try to decode `src` into `dst` using decoder `d`.
 Return the size of the decoded output in `dst` if successful.
 
 If `dst` is too small to fit the decoded output, return `NOT_SIZE`.
-If a hint of the size can be found, return `MaybeSize(-hint)`.
+If `dst` is too small but a hint of the required size can be found, return `MaybeSize(-hint)`.
 
 Throw a [`DecodingError`](@ref) if decoding fails because the input data is not valid.
 
@@ -213,7 +213,7 @@ Return the size of the decoded output in `dst` if successful.
 `dst` can be grown using the `resize!` function to any size between one more than the original length of `dst` and `max_size`.
 
 Return `NOT_SIZE` if the size of `dst` is too small to contain the decoded output and cannot be grown due to the `max_size` restriction.
-If a hint of the size can be found, return `MaybeSize(-hint)`.
+If a positive hint of the size can be found, return `MaybeSize(-hint)`.
 
 Precondition: `dst` and `src` do not overlap in memory.
 

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -17,7 +17,7 @@ function encode(e, src::AbstractVector{UInt8})::Vector{UInt8}
     dst_size::Int64 = encode_bound(e, src_size)
     @assert !signbit(dst_size)
     dst = Vector{UInt8}(undef, dst_size)
-    real_dst_size = something(try_encode!(e, dst, src))
+    real_dst_size::Int64 = try_encode!(e, dst, src)
     @assert real_dst_size ∈ 0:dst_size
     if real_dst_size < dst_size
         resize!(dst, real_dst_size)
@@ -51,14 +51,15 @@ function decode(
     )::Vector{UInt8}
     _clamp_max_size::Int64 = clamp(max_size, Int64)
     if _clamp_max_size < Int64(0)
-        throw(DecodedSizeError(_clamp_max_size, nothing))
+        throw(DecodedSizeError(_clamp_max_size, NOT_SIZE))
     end
     _clamp_size_hint::Int64 = clamp(size_hint, Int64(0), _clamp_max_size)
     dst = Vector{UInt8}(undef, _clamp_size_hint)
-    real_dst_size = try_resize_decode!(d, dst, src, _clamp_max_size)::Union{Nothing, Int64}
-    if isnothing(real_dst_size)
-        throw(DecodedSizeError(_clamp_max_size, try_find_decoded_size(d, src)))
+    maybe_dst_size = try_resize_decode!(d, dst, src, _clamp_max_size)::MaybeSize
+    if !is_size(maybe_dst_size)
+        throw(DecodedSizeError(_clamp_max_size, maybe_dst_size))
     end
+    real_dst_size = Int64(maybe_dst_size)
     @assert real_dst_size ∈ 0:_clamp_max_size
     @assert real_dst_size ≤ length(dst)
     resize!(dst, real_dst_size)
@@ -83,8 +84,8 @@ See also [`decode`](@ref) and [`encode`](@ref)
 """
 function decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8})
     expected_size::Int64 = length(dst)
-    n = try_decode!(d, dst, src)
-    if n != expected_size
+    n = try_decode!(d, dst, src)::MaybeSize
+    if n.val != expected_size
         throw(DecodedSizeError(expected_size, n))
     else
         dst
@@ -130,13 +131,13 @@ On the domain of `0:typemax(Int64)` this function must not error and must be mon
 function encode_bound end
 
 """
-    try_encode!(e, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+    try_encode!(e, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
 
 Try to encode `src` into `dst` using encoder `e`.
 
 Return the size of the encoded output in `dst` if successful.
 
-If `dst` is too small, return `nothing`.
+If `dst` is too small, return `NOT_SIZE`.
 
 Throw an error if `length(src)` is not in `decoded_size_range(e)`
 
@@ -168,27 +169,28 @@ Return `true` if the encoder is lossless.
 is_lossless(::Any) = true
 
 """
-    try_find_decoded_size(d, src::AbstractVector{UInt8})::Union{Nothing, Int64}
+    try_find_decoded_size(d, src::AbstractVector{UInt8})::MaybeSize
 
 Try to return the size of the decoded output of `src` using `d`.
 
-If the size cannot be quickly determined, return `nothing`.
+If the size cannot be quickly determined, return `NOT_SIZE`.
 
 If the encoded data is found to be invalid, throw a `DecodingError`.
 
-This if an `Int64` is returned, it must be the exact size of the decoded output.
+If a `is_size` size is returned, it must be the exact size of the decoded output.
 If [`try_decode!`](@ref) is called with a `dst` of this size, it must succeed and return the same size, or throw an error.
 """
 function try_find_decoded_size end
 
 """
-    try_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+    try_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
 
 Try to decode `src` into `dst` using decoder `d`.
 
 Return the size of the decoded output in `dst` if successful.
 
-If `dst` is too small to fit the decoded output, return `nothing`.
+If `dst` is too small to fit the decoded output, return `NOT_SIZE`.
+If a hint of the size can be found, return `MaybeSize(-hint)`.
 
 Throw a [`DecodingError`](@ref) if decoding fails because the input data is not valid.
 
@@ -202,7 +204,7 @@ Only the initial returned number of bytes are valid output.
 function try_decode! end
 
 """
-    try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}
+    try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
 
 Try to decode the input `src` into `dst` using decoder `d`.
 
@@ -210,36 +212,44 @@ Return the size of the decoded output in `dst` if successful.
 
 `dst` can be grown using the `resize!` function to any size between one more than the original length of `dst` and `max_size`.
 
-Return `nothing` if the size of `dst` is too small to contain the decoded output and cannot be grown due to the `max_size` restriction.
+Return `NOT_SIZE` if the size of `dst` is too small to contain the decoded output and cannot be grown due to the `max_size` restriction.
+If a hint of the size can be found, return `MaybeSize(-hint)`.
 
 Precondition: `dst` and `src` do not overlap in memory.
 
 All of `dst` can be written to or used as scratch space by the decoder.
 Only the initial returned number of bytes are valid output.
 """
-function try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}
-    decoded_size = try_find_decoded_size(d, src)::Union{Nothing, Int64}
-    if isnothing(decoded_size)
+function try_resize_decode!(d, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
+    maybe_decoded_size = try_find_decoded_size(d, src)::MaybeSize
+    if !is_size(maybe_decoded_size)
         while true
-            ds = try_decode!(d, dst, src)::Union{Nothing, Int64}
-            if isnothing(ds)
-                if isnothing(grow_dst!(dst, max_size))
-                    return nothing
+            ds = try_decode!(d, dst, src)::MaybeSize
+            if !is_size(ds)
+                if length(dst) ≥ max_size
+                    return ds
+                end
+                local hint = -ds.val
+                if hint ≤ length(dst)
+                    grow_dst!(dst, max_size)
+                else
+                    resize!(dst, min(hint, max_size))
                 end
             else
-                @assert ds ∈ 0:length(dst)
+                @assert Int64(ds) ∈ 0:length(dst)
                 return ds
             end
         end
     else
+        decoded_size = Int64(maybe_decoded_size)
         if decoded_size > length(dst)
             if decoded_size > max_size
-                return nothing
+                return MaybeSize(-decoded_size)
             end
             resize!(dst, decoded_size)
         end
-        real_dst_size = something(try_decode!(d, dst, src))
-        @assert real_dst_size == decoded_size
+        real_dst_size = try_decode!(d, dst, src)::MaybeSize
+        @assert Int64(real_dst_size) == decoded_size
         return real_dst_size
     end
 end

--- a/ChunkCodecCore/src/noop.jl
+++ b/ChunkCodecCore/src/noop.jl
@@ -43,7 +43,7 @@ function try_encode!(e::NoopEncodeOptions, dst::AbstractVector{UInt8}, src::Abst
     src_size::Int64 = length(src)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        nothing
+        NOT_SIZE
     else
         copyto!(dst, src)
         src_size
@@ -72,15 +72,15 @@ end
 
 is_thread_safe(::NoopDecodeOptions) = true
 
-function try_find_decoded_size(::NoopDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
-    MaybeSize(length(src))
+function try_find_decoded_size(::NoopDecodeOptions, src::AbstractVector{UInt8})::Int64
+    length(src)
 end
 
 function try_decode!(::NoopDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     if dst_size < src_size
-        MaybeSize(-src_size)
+        NOT_SIZE
     else
         copyto!(dst, src)
         MaybeSize(src_size)

--- a/ChunkCodecCore/src/noop.jl
+++ b/ChunkCodecCore/src/noop.jl
@@ -43,10 +43,10 @@ function try_encode!(e::NoopEncodeOptions, dst::AbstractVector{UInt8}, src::Abst
     src_size::Int64 = length(src)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        MaybeSize(-src_size)
+        nothing
     else
         copyto!(dst, src)
-        MaybeSize(src_size)
+        src_size
     end
 end
 

--- a/ChunkCodecCore/src/noop.jl
+++ b/ChunkCodecCore/src/noop.jl
@@ -38,15 +38,15 @@ decoded_size_range(::NoopEncodeOptions) = Int64(0):Int64(1):typemax(Int64)-Int64
 
 encode_bound(::NoopEncodeOptions, src_size::Int64)::Int64 = src_size
 
-function try_encode!(e::NoopEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::NoopEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        nothing
+        MaybeSize(-src_size)
     else
         copyto!(dst, src)
-        src_size
+        MaybeSize(src_size)
     end
 end
 
@@ -72,17 +72,17 @@ end
 
 is_thread_safe(::NoopDecodeOptions) = true
 
-function try_find_decoded_size(::NoopDecodeOptions, src::AbstractVector{UInt8})::Int64
-    length(src)
+function try_find_decoded_size(::NoopDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+    MaybeSize(length(src))
 end
 
-function try_decode!(::NoopDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(::NoopDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     if dst_size < src_size
-        nothing
+        MaybeSize(-src_size)
     else
         copyto!(dst, src)
-        src_size
+        MaybeSize(src_size)
     end
 end

--- a/ChunkCodecCore/src/shuffle.jl
+++ b/ChunkCodecCore/src/shuffle.jl
@@ -57,7 +57,7 @@ function try_encode!(e::ShuffleCodec, dst::AbstractVector{UInt8}, src::AbstractV
     element_size = e.element_size
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        nothing
+        NOT_SIZE
     else
         if src_size>>1 < element_size || element_size == 1
             copyto!(dst, src)
@@ -129,8 +129,8 @@ end
 
 is_thread_safe(::ShuffleDecodeOptions) = true
 
-function try_find_decoded_size(::ShuffleDecodeOptions, src::AbstractVector{UInt8})
-    MaybeSize(length(src))
+function try_find_decoded_size(::ShuffleDecodeOptions, src::AbstractVector{UInt8})::Int64
+    length(src)
 end
 
 function try_decode!(d::ShuffleDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
@@ -138,7 +138,7 @@ function try_decode!(d::ShuffleDecodeOptions, dst::AbstractVector{UInt8}, src::A
     src_size::Int64 = length(src)
     element_size = d.codec.element_size
     if dst_size < src_size
-        MaybeSize(-src_size)
+        NOT_SIZE
     else
         if src_size>>1 < element_size || element_size == 1
             copyto!(dst, src)

--- a/ChunkCodecCore/src/shuffle.jl
+++ b/ChunkCodecCore/src/shuffle.jl
@@ -57,11 +57,11 @@ function try_encode!(e::ShuffleCodec, dst::AbstractVector{UInt8}, src::AbstractV
     element_size = e.element_size
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        MaybeSize(-src_size)
+        nothing
     else
         if src_size>>1 < element_size || element_size == 1
             copyto!(dst, src)
-            return MaybeSize(src_size)
+            return src_size
         end
         n_elements, n_remainder = fldmod(src_size, element_size)
         @inbounds for i in 0:(element_size-1)
@@ -73,7 +73,7 @@ function try_encode!(e::ShuffleCodec, dst::AbstractVector{UInt8}, src::AbstractV
         for i in 0:(n_remainder-1)
             dst[begin + offset + i] = src[begin + offset + i]
         end
-        return MaybeSize(src_size)
+        return src_size
     end
 end
 

--- a/ChunkCodecCore/src/types.jl
+++ b/ChunkCodecCore/src/types.jl
@@ -26,7 +26,7 @@ All `EncodeOptions` have a `codec::Codec` property.
 Required methods for a type `T <: EncodeOptions` to implement:
 - `decoded_size_range(::T)::StepRange{Int64, Int64}`
 - `encode_bound(::T, src_size::Int64)::Int64`
-- `try_encode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}`
+- `try_encode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize`
 
 Optional methods to implement:
 - `is_thread_safe(::T)::Bool`: defaults to `false`.
@@ -46,11 +46,11 @@ that accept all properties as arguments.
 All `DecodeOptions` have a `codec::Codec` property.
 
 Required methods for a type `T <: DecodeOptions` to implement:
-- `try_find_decoded_size(::T, src::AbstractVector{UInt8})::Union{Nothing, Int64}`
-- `try_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}`
+- `try_find_decoded_size(::T, src::AbstractVector{UInt8})::MaybeSize`
+- `try_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize`
 
 Optional methods to implement:
 - `is_thread_safe(::T)::Bool`: defaults to `false`.
-- `try_resize_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}`: defaults to using `try_decode!` and `try_find_decoded_size`
+- `try_resize_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize`: defaults to using `try_decode!` and `try_find_decoded_size`
 """
 abstract type DecodeOptions end

--- a/ChunkCodecCore/src/types.jl
+++ b/ChunkCodecCore/src/types.jl
@@ -46,7 +46,7 @@ that accept all properties as arguments.
 All `DecodeOptions` have a `codec::Codec` property.
 
 Required methods for a type `T <: DecodeOptions` to implement:
-- `try_find_decoded_size(::T, src::AbstractVector{UInt8})::MaybeSize`
+- `try_find_decoded_size(::T, src::AbstractVector{UInt8})::Union{Nothing, Int64}`
 - `try_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize`
 
 Optional methods to implement:

--- a/ChunkCodecCore/test/runtests.jl
+++ b/ChunkCodecCore/test/runtests.jl
@@ -36,6 +36,33 @@ end
     @test_throws ArgumentError ShuffleCodec(-1)
     @test_throws ArgumentError ShuffleCodec(typemin(Int64))
 end
+@testset "converting MaybeSize" begin
+    @test is_size(MaybeSize(0))
+    @test is_size(MaybeSize(typemax(Int64)))
+    @test !is_size(MaybeSize(-1))
+    @test !is_size(MaybeSize(typemin(Int64)))
+
+    @test Int64(MaybeSize(0)) === Int64(0)
+    @test Int64(MaybeSize(typemax(Int64))) === Int64(typemax(Int64))
+    @test_throws InexactError Int64(MaybeSize(-1))
+    @test_throws InexactError Int64(MaybeSize(typemin(Int64)))
+
+    @test convert(Int64, MaybeSize(0)) === Int64(0)
+    @test convert(Int64, MaybeSize(typemax(Int64))) === Int64(typemax(Int64))
+    @test_throws InexactError convert(Int64, MaybeSize(-1))
+    @test_throws InexactError convert(Int64, MaybeSize(typemin(Int64)))
+
+    @test convert(MaybeSize, Int64(0)) === MaybeSize(0)
+    @test convert(MaybeSize, typemax(Int64)) === MaybeSize(typemax(Int64))
+    @test_throws InexactError convert(MaybeSize, Int64(-1))
+    @test_throws InexactError convert(MaybeSize, typemin(Int64))
+
+    @test convert(MaybeSize, nothing) === MaybeSize(typemin(Int64))
+    @test convert(Nothing, MaybeSize(typemin(Int64))) === nothing
+    @test_throws InexactError convert(Nothing, MaybeSize(0))
+    @test_throws InexactError convert(Nothing, MaybeSize(typemax(Int64)))
+    @test_throws InexactError convert(Nothing, MaybeSize(-1))
+end
 @testset "errors" begin
     @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(2))) == "DecodedSizeError: decoded size: 2 is greater than max size: 1"
     @test sprint(Base.showerror, DecodedSizeError(2, MaybeSize(1))) == "DecodedSizeError: decoded size: 1 is less than expected size: 2"

--- a/ChunkCodecCore/test/runtests.jl
+++ b/ChunkCodecCore/test/runtests.jl
@@ -58,10 +58,10 @@ end
     @test_throws InexactError convert(MaybeSize, typemin(Int64))
 end
 @testset "errors" begin
-    @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(2))) == "DecodedSizeError: decoded size: 2 is greater than max size: 1"
-    @test sprint(Base.showerror, DecodedSizeError(2, MaybeSize(1))) == "DecodedSizeError: decoded size: 1 is less than expected size: 2"
-    @test sprint(Base.showerror, DecodedSizeError(1, NOT_SIZE)) == "DecodedSizeError: decoded size is greater than max size: 1"
-    @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(-10))) == "DecodedSizeError: decoded size is greater than max size: 1 decoder hints to try with 10 bytes"
+    @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(2))) == "DecodedSizeError: decoded size 2 > 1"
+    @test sprint(Base.showerror, DecodedSizeError(2, MaybeSize(1))) == "DecodedSizeError: decoded size 1 < expected 2"
+    @test sprint(Base.showerror, DecodedSizeError(1, NOT_SIZE)) == "DecodedSizeError: decoded size > 1"
+    @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(-10))) == "DecodedSizeError: decoded size > 1, try max_size = 10"
 end
 @testset "check helpers" begin
     @test_throws Exception ChunkCodecCore.check_contiguous(@view(zeros(UInt8, 8)[1:2:end]))

--- a/ChunkCodecCore/test/runtests.jl
+++ b/ChunkCodecCore/test/runtests.jl
@@ -56,12 +56,6 @@ end
     @test convert(MaybeSize, typemax(Int64)) === MaybeSize(typemax(Int64))
     @test_throws InexactError convert(MaybeSize, Int64(-1))
     @test_throws InexactError convert(MaybeSize, typemin(Int64))
-
-    @test convert(MaybeSize, nothing) === MaybeSize(typemin(Int64))
-    @test convert(Nothing, MaybeSize(typemin(Int64))) === nothing
-    @test_throws InexactError convert(Nothing, MaybeSize(0))
-    @test_throws InexactError convert(Nothing, MaybeSize(typemax(Int64)))
-    @test_throws InexactError convert(Nothing, MaybeSize(-1))
 end
 @testset "errors" begin
     @test sprint(Base.showerror, DecodedSizeError(1, MaybeSize(2))) == "DecodedSizeError: decoded size: 2 is greater than max size: 1"
@@ -108,7 +102,7 @@ function TestDecodeOptions(;
     )
     TestDecodeOptions(codec)
 end
-ChunkCodecCore.try_find_decoded_size(::TestDecodeOptions, src::AbstractVector{UInt8}) = NOT_SIZE
+ChunkCodecCore.try_find_decoded_size(::TestDecodeOptions, src::AbstractVector{UInt8}) = nothing
 function ChunkCodecCore.try_decode!(::TestDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
@@ -134,7 +128,7 @@ function RandHintDecodeOptions(;
     )
     RandHintDecodeOptions(codec)
 end
-ChunkCodecCore.try_find_decoded_size(::RandHintDecodeOptions, src::AbstractVector{UInt8}) = NOT_SIZE
+ChunkCodecCore.try_find_decoded_size(::RandHintDecodeOptions, src::AbstractVector{UInt8}) = nothing
 function ChunkCodecCore.try_decode!(::RandHintDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)

--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.1.5](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.5) - 2025-07-28

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecTests"
 uuid = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.6"
+version = "0.1.6-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -1,13 +1,13 @@
 name = "ChunkCodecTests"
 uuid = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChunkCodecCore = "0.5.1"
+ChunkCodecCore = "0.6"
 Test = "1"
 julia = "1.6"

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -95,9 +95,9 @@ function test_encoder_decoder(e, d; trials=100)
             @test !is_size(try_encode!(e, zeros(UInt8, length(encoded)-1), data))
         end
         local ds = try_find_decoded_size(d, encoded)
-        @test ds isa MaybeSize
-        if is_size(ds)
-            @test Int64(ds) === s
+        @test ds isa Union{Nothing, Int64}
+        if !isnothing(ds)
+            @test ds === s
         end
         local dst = zeros(UInt8, s)
         @test try_decode!(d, dst, encoded) === MaybeSize(s)

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -18,7 +18,6 @@ using ChunkCodecCore:
     try_decode!,
     try_resize_decode!,
     MaybeSize,
-    NOT_SIZE,
     is_size
 
 using Test: Test, @test, @test_throws

--- a/LibAec/CHANGELOG.md
+++ b/LibAec/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.1.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibAec-v0.1.2) - 2025-07-28

--- a/LibAec/Project.toml
+++ b/LibAec/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibAec"
 uuid = "50eb285c-f72d-40fd-bb37-8ab277ca8a2c"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.2"
+version = "0.2.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 libaec_jll = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
 
 [compat]
-ChunkCodecCore = "0.5.1"
+ChunkCodecCore = "0.6"
 libaec_jll = "1"
 julia = "1.6"
 

--- a/LibAec/src/ChunkCodecLibAec.jl
+++ b/LibAec/src/ChunkCodecLibAec.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_in_range,
     check_contiguous,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibAec/src/ChunkCodecLibAec.jl
+++ b/LibAec/src/ChunkCodecLibAec.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_in_range,
     check_contiguous,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibAec/src/decode.jl
+++ b/LibAec/src/decode.jl
@@ -33,7 +33,7 @@ function SzipHDF5DecodeOptions(;
     SzipHDF5DecodeOptions(codec)
 end
 
-function try_find_decoded_size(::SzipHDF5DecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::SzipHDF5DecodeOptions, src::AbstractVector{UInt8})::Int64
     if length(src) < 4
         throw(SzipDecodingError("unexpected end of input"))
     else
@@ -52,7 +52,7 @@ function try_decode!(d::SzipHDF5DecodeOptions, dst::AbstractVector{UInt8}, src::
     src_size::Int64 = length(src)
     dst_size::Int64 = length(dst)
     if decoded_size > dst_size
-        nothing
+        return NOT_SIZE
     else
         cconv_src = Base.cconvert(Ptr{UInt8}, src)
         cconv_dst = Base.cconvert(Ptr{UInt8}, dst)

--- a/LibAec/src/decode.jl
+++ b/LibAec/src/decode.jl
@@ -33,7 +33,7 @@ function SzipHDF5DecodeOptions(;
     SzipHDF5DecodeOptions(codec)
 end
 
-function try_find_decoded_size(::SzipHDF5DecodeOptions, src::AbstractVector{UInt8})::Int64
+function try_find_decoded_size(::SzipHDF5DecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     if length(src) < 4
         throw(SzipDecodingError("unexpected end of input"))
     else
@@ -45,11 +45,10 @@ function try_find_decoded_size(::SzipHDF5DecodeOptions, src::AbstractVector{UInt
     end
 end
 
-function try_decode!(d::SzipHDF5DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::SzipHDF5DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
-    decoded_size = try_find_decoded_size(d, src)
-    @assert !isnothing(decoded_size)
+    decoded_size::Int64 = try_find_decoded_size(d, src)
     src_size::Int64 = length(src)
     dst_size::Int64 = length(dst)
     if decoded_size > dst_size

--- a/LibAec/src/encode.jl
+++ b/LibAec/src/encode.jl
@@ -47,7 +47,7 @@ function encode_bound(x::SzipHDF5Codec, src_size::Int64)::Int64
     return cld(max_output_bits, 8) + 4
 end
 
-function try_encode!(e::SzipHDF5Codec, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::SzipHDF5Codec, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)
@@ -127,6 +127,6 @@ decoded_size_range(e::SzipHDF5EncodeOptions) = decoded_size_range(e.codec)
 
 encode_bound(e::SzipHDF5EncodeOptions, src_size::Int64)::Int64 = encode_bound(e.codec, src_size)
 
-function try_encode!(e::SzipHDF5EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::SzipHDF5EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     try_encode!(e.codec, dst, src)
 end

--- a/LibAec/src/encode.jl
+++ b/LibAec/src/encode.jl
@@ -54,7 +54,7 @@ function try_encode!(e::SzipHDF5Codec, dst::AbstractVector{UInt8}, src::Abstract
     dst_size::Int64 = length(dst)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < 4
-        return nothing
+        return NOT_SIZE
     end
     cconv_src = Base.cconvert(Ptr{UInt8}, src)
     cconv_dst = Base.cconvert(Ptr{UInt8}, dst)
@@ -88,7 +88,7 @@ function try_encode!(e::SzipHDF5Codec, dst::AbstractVector{UInt8}, src::Abstract
     elseif ret == SZ_MEM_ERROR
         throw(OutOfMemoryError())
     elseif ret == SZ_OUTBUFF_FULL
-        return nothing
+        return NOT_SIZE
     elseif ret == SZ_PARAM_ERROR
         throw(ArgumentError("invalid szip parameters"))
     else

--- a/LibBlosc/CHANGELOG.md
+++ b/LibBlosc/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBlosc-v0.2.1) - 2025-07-28

--- a/LibBlosc/Project.toml
+++ b/LibBlosc/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecLibBlosc"
 uuid = "c6a955be-ab7f-4fbb-b38f-caf93db6b928"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 Blosc_jll = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
@@ -9,7 +9,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
 Blosc_jll = "1"
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 julia = "1.6"
 
 [workspace]

--- a/LibBlosc/src/ChunkCodecLibBlosc.jl
+++ b/LibBlosc/src/ChunkCodecLibBlosc.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_in_range,
     check_contiguous,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibBlosc/src/ChunkCodecLibBlosc.jl
+++ b/LibBlosc/src/ChunkCodecLibBlosc.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_in_range,
     check_contiguous,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibBlosc/src/decode.jl
+++ b/LibBlosc/src/decode.jl
@@ -33,7 +33,7 @@ function BloscDecodeOptions(;
     BloscDecodeOptions(codec)
 end
 
-function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})::Int64
+function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     check_contiguous(src)
     nbytes = Ref(Csize_t(0))
     ret = ccall((:blosc_cbuffer_validate, libblosc), Cint,
@@ -49,11 +49,11 @@ function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})
     end
 end
 
-function try_decode!(d::BloscDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::BloscDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     # This makes sure it is safe to decompress.
-    nbytes = try_find_decoded_size(d, src)
+    nbytes::Int64 = try_find_decoded_size(d, src)
     dst_size::Int64 = length(dst)
     if nbytes > dst_size
         nothing

--- a/LibBlosc/src/decode.jl
+++ b/LibBlosc/src/decode.jl
@@ -33,7 +33,7 @@ function BloscDecodeOptions(;
     BloscDecodeOptions(codec)
 end
 
-function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})::Int64
     check_contiguous(src)
     nbytes = Ref(Csize_t(0))
     ret = ccall((:blosc_cbuffer_validate, libblosc), Cint,
@@ -56,7 +56,7 @@ function try_decode!(d::BloscDecodeOptions, dst::AbstractVector{UInt8}, src::Abs
     nbytes::Int64 = try_find_decoded_size(d, src)
     dst_size::Int64 = length(dst)
     if nbytes > dst_size
-        nothing
+        NOT_SIZE
     else
         numinternalthreads = 1
         sz = ccall((:blosc_decompress_ctx, libblosc), Cint,

--- a/LibBlosc/src/encode.jl
+++ b/LibBlosc/src/encode.jl
@@ -61,7 +61,7 @@ function encode_bound(::BloscEncodeOptions, src_size::Int64)::Int64
     clamp(widen(src_size) + widen(BLOSC_MAX_OVERHEAD), Int64)
 end
 
-function try_encode!(e::BloscEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::BloscEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/LibBlosc/src/encode.jl
+++ b/LibBlosc/src/encode.jl
@@ -82,7 +82,7 @@ function try_encode!(e::BloscEncodeOptions, dst::AbstractVector{UInt8}, src::Abs
         e.clevel, e.doshuffle, e.typesize, src_size, src, dst, dst_size, e.compressor, blocksize, numinternalthreads
     )
     if sz == 0
-        nothing
+        NOT_SIZE
     elseif sz < 0
         error("Internal Blosc error: $(sz). This
             should never happen.  If you see this, please report it back

--- a/LibBrotli/CHANGELOG.md
+++ b/LibBrotli/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBrotli-v0.2.1) - 2025-07-28

--- a/LibBrotli/Project.toml
+++ b/LibBrotli/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibBrotli"
 uuid = "653b0ff7-85b5-4442-93c1-dcc330d3ec7d"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 brotli_jll = "4611771a-a7d2-5e23-8d00-b1becdba1aae"
 
 [compat]
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 brotli_jll = "1"
 julia = "1.6"
 

--- a/LibBrotli/src/ChunkCodecLibBrotli.jl
+++ b/LibBrotli/src/ChunkCodecLibBrotli.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_contiguous,
     check_in_range,
     grow_dst!,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibBrotli/src/ChunkCodecLibBrotli.jl
+++ b/LibBrotli/src/ChunkCodecLibBrotli.jl
@@ -10,7 +10,8 @@ using ChunkCodecCore:
     check_in_range,
     grow_dst!,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibBrotli/src/decode.jl
+++ b/LibBrotli/src/decode.jl
@@ -38,7 +38,7 @@ end
 # https://github.com/google/brotli/issues/501
 is_thread_safe(::BrotliDecodeOptions) = true
 
-function try_find_decoded_size(::BrotliDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::BrotliDecodeOptions, src::AbstractVector{UInt8})::Nothing
     nothing
 end
 
@@ -96,7 +96,7 @@ function try_resize_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, 
                     @assert iszero(dst_left)
                     local next_size = grow_dst!(dst, max_size)
                     if isnothing(next_size)
-                        return nothing
+                        return NOT_SIZE
                     end
                     dst_left += next_size - dst_size
                     dst_size = next_size

--- a/LibBrotli/src/decode.jl
+++ b/LibBrotli/src/decode.jl
@@ -130,6 +130,7 @@ function try_resize_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, 
                 end
             end
         end
+        @assert false "unreachable"
     finally
         @ccall libbrotlidec.BrotliDecoderDestroyInstance(
             s::Ptr{BrotliDecoderState},

--- a/LibBrotli/src/decode.jl
+++ b/LibBrotli/src/decode.jl
@@ -38,15 +38,15 @@ end
 # https://github.com/google/brotli/issues/501
 is_thread_safe(::BrotliDecodeOptions) = true
 
-function try_find_decoded_size(::BrotliDecodeOptions, src::AbstractVector{UInt8})::Nothing
+function try_find_decoded_size(::BrotliDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     nothing
 end
 
-function try_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     try_resize_decode!(d, dst, src, Int64(length(dst)))
 end
 
-function try_resize_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}
+function try_resize_decode!(d::BrotliDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     src_left::Int64 = src_size

--- a/LibBrotli/src/encode.jl
+++ b/LibBrotli/src/encode.jl
@@ -81,7 +81,7 @@ function try_encode!(e::BrotliEncodeOptions, dst::AbstractVector{UInt8}, src::Ab
     clamped_dst_size = min(dst_size, max_out_size)
     if iszero(dst_size)
         # Output buffer needs at least one byte.
-        return nothing
+        return NOT_SIZE
     end
     cconv_src = Base.cconvert(Ptr{UInt8}, src)
     cconv_dst = Base.cconvert(Ptr{UInt8}, dst)
@@ -142,7 +142,7 @@ function try_encode!(e::BrotliEncodeOptions, dst::AbstractVector{UInt8}, src::Ab
                     if dst_size ≥ max_out_size
                         return unsafe_MakeUncompressedStream(src_p, src_size, dst_p)
                     else
-                        return nothing
+                        return NOT_SIZE
                     end
                 end
             else

--- a/LibBrotli/src/encode.jl
+++ b/LibBrotli/src/encode.jl
@@ -67,7 +67,7 @@ function decoded_size_range(::BrotliEncodeOptions)
     Int64(0):Int64(1):Int64(0x7ff8007ff8007ff4)
 end
 
-function try_encode!(e::BrotliEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::BrotliEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/LibBzip2/CHANGELOG.md
+++ b/LibBzip2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibBzip2-v0.2.1) - 2025-07-28

--- a/LibBzip2/Project.toml
+++ b/LibBzip2/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecLibBzip2"
 uuid = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
@@ -9,7 +9,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
 Bzip2_jll = "1"
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 julia = "1.6"
 
 [workspace]

--- a/LibBzip2/src/ChunkCodecLibBzip2.jl
+++ b/LibBzip2/src/ChunkCodecLibBzip2.jl
@@ -10,7 +10,8 @@ using ChunkCodecCore:
     check_contiguous,
     grow_dst!,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibBzip2/src/ChunkCodecLibBzip2.jl
+++ b/LibBzip2/src/ChunkCodecLibBzip2.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_in_range,
     check_contiguous,
     grow_dst!,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibBzip2/src/decode.jl
+++ b/LibBzip2/src/decode.jl
@@ -46,7 +46,7 @@ function BZ2DecodeOptions(;
 end
 is_thread_safe(::BZ2DecodeOptions) = true
 
-function try_find_decoded_size(::BZ2DecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::BZ2DecodeOptions, src::AbstractVector{UInt8})::Nothing
     nothing
 end
 
@@ -104,7 +104,7 @@ function try_resize_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src
                         elseif iszero(dst_left) # needs more output
                             local next_size = grow_dst!(dst, max_size)
                             if isnothing(next_size)
-                                return nothing
+                                return NOT_SIZE
                             end
                             dst_left += next_size - dst_size
                             dst_size = next_size

--- a/LibBzip2/src/decode.jl
+++ b/LibBzip2/src/decode.jl
@@ -46,15 +46,15 @@ function BZ2DecodeOptions(;
 end
 is_thread_safe(::BZ2DecodeOptions) = true
 
-function try_find_decoded_size(::BZ2DecodeOptions, src::AbstractVector{UInt8})::Nothing
+function try_find_decoded_size(::BZ2DecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     nothing
 end
 
-function try_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     try_resize_decode!(d, dst, src, Int64(length(dst)))
 end
 
-function try_resize_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}
+function try_resize_decode!(d::BZ2DecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     src_left::Int64 = src_size

--- a/LibBzip2/src/encode.jl
+++ b/LibBzip2/src/encode.jl
@@ -50,7 +50,7 @@ function try_encode!(e::BZ2EncodeOptions, dst::AbstractVector{UInt8}, src::Abstr
     dst_size::Int64 = length(dst)
     check_in_range(decoded_size_range(e); src_size)
     if iszero(dst_size)
-        return nothing
+        return NOT_SIZE
     end
     stream = BZStream()
     BZ2_bzCompressInit(stream, e.blockSize100k)
@@ -96,7 +96,7 @@ function try_encode!(e::BZ2EncodeOptions, dst::AbstractVector{UInt8}, src::Abstr
                 end
                 if iszero(dst_left)
                     # no more space, but not BZ_STREAM_END
-                    return nothing
+                    return NOT_SIZE
                 end
                 if action == BZ_RUN
                     @assert ret == BZ_RUN_OK

--- a/LibBzip2/src/encode.jl
+++ b/LibBzip2/src/encode.jl
@@ -43,7 +43,7 @@ function encode_bound(::BZ2EncodeOptions, src_size::Int64)::Int64
     clamp(widen(src_size) + widen(src_size>>6 + Int64(601)), Int64)
 end
 
-function try_encode!(e::BZ2EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::BZ2EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/LibLz4/CHANGELOG.md
+++ b/LibLz4/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.2](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibLz4-v0.2.2) - 2025-07-28

--- a/LibLz4/Project.toml
+++ b/LibLz4/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibLz4"
 uuid = "7e9cc85e-5614-42a3-ad86-b78f920b38a5"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.2"
+version = "0.3.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Lz4_jll = "5ced341a-0733-55b8-9ab6-a4889d929147"
 
 [compat]
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 Lz4_jll = "1"
 julia = "1.6"
 

--- a/LibLz4/src/ChunkCodecLibLz4.jl
+++ b/LibLz4/src/ChunkCodecLibLz4.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_contiguous,
     check_in_range,
     grow_dst!,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibLz4/src/ChunkCodecLibLz4.jl
+++ b/LibLz4/src/ChunkCodecLibLz4.jl
@@ -10,7 +10,8 @@ using ChunkCodecCore:
     check_in_range,
     grow_dst!,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibLz4/src/decode.jl
+++ b/LibLz4/src/decode.jl
@@ -367,7 +367,6 @@ function try_decode!(d::LZ4NumcodecsDecodeOptions, dst::AbstractVector{UInt8}, s
     check_contiguous(dst)
     check_contiguous(src)
     decoded_size::Int64 = try_find_decoded_size(d, src)
-    @assert !isnothing(decoded_size)
     src_size::Int64 = length(src)
     if src_size-4 > typemax(Int32)
         throw(LZ4DecodingError("encoded size is larger than `typemax(Int32) + 4`"))

--- a/LibLz4/src/decode.jl
+++ b/LibLz4/src/decode.jl
@@ -43,7 +43,7 @@ end
 
 is_thread_safe(::LZ4FrameDecodeOptions) = true
 
-function try_find_decoded_size(::LZ4FrameDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::LZ4FrameDecodeOptions, src::AbstractVector{UInt8})::Nothing
     # TODO This might be possible to do using a method similar to ZstdDecodeOptions
     # For now just return nothing
     nothing
@@ -110,7 +110,7 @@ function try_resize_decode!(d::LZ4FrameDecodeOptions, dst::AbstractVector{UInt8}
                             if iszero(dst_left) # needs more output
                                 local next_size = grow_dst!(dst, max_size)
                                 if isnothing(next_size)
-                                    return nothing
+                                    return NOT_SIZE
                                 end
                                 dst_left += next_size - dst_size
                                 dst_size = next_size
@@ -164,7 +164,7 @@ end
 is_thread_safe(::LZ4BlockDecodeOptions) = true
 
 # There is no header or footer, so always return nothing
-function try_find_decoded_size(::LZ4BlockDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::LZ4BlockDecodeOptions, src::AbstractVector{UInt8})::Nothing
     nothing
 end
 
@@ -347,7 +347,7 @@ end
 
 is_thread_safe(::LZ4NumcodecsDecodeOptions) = true
 
-function try_find_decoded_size(::LZ4NumcodecsDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::LZ4NumcodecsDecodeOptions, src::AbstractVector{UInt8})::Int64
     if length(src) < 4
         throw(LZ4DecodingError("unexpected end of input"))
     else
@@ -374,7 +374,7 @@ function try_decode!(d::LZ4NumcodecsDecodeOptions, dst::AbstractVector{UInt8}, s
     src_size32 = (src_size-4)%Int32
     dst_size::Int64 = length(dst)
     if decoded_size > dst_size
-        nothing
+        return NOT_SIZE
     else
         cconv_src = Base.cconvert(Ptr{UInt8}, src)
         cconv_dst = Base.cconvert(Ptr{UInt8}, dst)
@@ -423,7 +423,7 @@ end
 
 is_thread_safe(::LZ4HDF5DecodeOptions) = true
 
-function try_find_decoded_size(::LZ4HDF5DecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::LZ4HDF5DecodeOptions, src::AbstractVector{UInt8})::Int64
     if length(src) < 12
         throw(LZ4DecodingError("unexpected end of input"))
     else
@@ -454,7 +454,7 @@ function try_decode!(d::LZ4HDF5DecodeOptions, dst::AbstractVector{UInt8}, src::A
     src_size::Int64 = length(src)
     dst_size::Int64 = length(dst)
     if decoded_size > dst_size
-        return nothing
+        return NOT_SIZE
     end
     cconv_src = Base.cconvert(Ptr{UInt8}, src)
     cconv_dst = Base.cconvert(Ptr{UInt8}, dst)

--- a/LibLz4/src/encode.jl
+++ b/LibLz4/src/encode.jl
@@ -98,7 +98,7 @@ function encode_bound(e::LZ4FrameEncodeOptions, src_size::Int64)::Int64
     end
 end
 
-function try_encode!(e::LZ4FrameEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::LZ4FrameEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)
@@ -158,7 +158,7 @@ function encode_bound(::LZ4BlockEncodeOptions, src_size::Int64)::Int64
     end
 end
 
-function try_encode!(e::LZ4BlockEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::LZ4BlockEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)
@@ -228,7 +228,7 @@ function encode_bound(::LZ4NumcodecsEncodeOptions, src_size::Int64)::Int64
     end
 end
 
-function try_encode!(e::LZ4NumcodecsEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::LZ4NumcodecsEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)
@@ -309,7 +309,7 @@ function encode_bound(e::LZ4HDF5EncodeOptions, src_size::Int64)::Int64
     end
 end
 
-function try_encode!(e::LZ4HDF5EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::LZ4HDF5EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/LibLz4/src/encode.jl
+++ b/LibLz4/src/encode.jl
@@ -106,7 +106,7 @@ function try_encode!(e::LZ4FrameEncodeOptions, dst::AbstractVector{UInt8}, src::
     check_in_range(decoded_size_range(e); src_size)
     # LZ4F_compressFrame needs this to hold.
     if dst_size < encode_bound(e, src_size)
-        return nothing
+        return NOT_SIZE
     end
     ret = LZ4F_compressFrame(dst, src, _preferences(e))
     if LZ4F_isError(ret)
@@ -165,7 +165,7 @@ function try_encode!(e::LZ4BlockEncodeOptions, dst::AbstractVector{UInt8}, src::
     dst_size::Int64 = length(dst)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < 1
-        return nothing
+        return NOT_SIZE
     end
     # src_size must fit in an Int32 because it is in decoded_size_range(e)
     src_size32 = Int32(src_size)
@@ -177,7 +177,7 @@ function try_encode!(e::LZ4BlockEncodeOptions, dst::AbstractVector{UInt8}, src::
         unsafe_lz4_compress(src_p, dst_p, src_size32, clamp(dst_size, Int32), e.compressionLevel)
     end
     if iszero(ret)
-        nothing
+        NOT_SIZE
     else
         Int64(ret)
     end
@@ -235,7 +235,7 @@ function try_encode!(e::LZ4NumcodecsEncodeOptions, dst::AbstractVector{UInt8}, s
     dst_size::Int64 = length(dst)
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < 5
-        return nothing
+        return NOT_SIZE
     end
     # src_size must fit in an Int32 because it is in decoded_size_range(e)
     src_size32 = Int32(src_size)
@@ -252,7 +252,7 @@ function try_encode!(e::LZ4NumcodecsEncodeOptions, dst::AbstractVector{UInt8}, s
         unsafe_lz4_compress(src_p, dst_p, src_size32, clamp(dst_size, Int32), e.compressionLevel)
     end
     if iszero(ret)
-        nothing
+        NOT_SIZE
     else
         Int64(ret) + Int64(4)
     end
@@ -317,7 +317,7 @@ function try_encode!(e::LZ4HDF5EncodeOptions, dst::AbstractVector{UInt8}, src::A
     check_in_range(decoded_size_range(e); src_size)
     block_size = clamp(src_size, Int64(1), Int64(e.blockSize))
     if dst_size < 12
-        return nothing
+        return NOT_SIZE
     end
     cconv_src = Base.cconvert(Ptr{UInt8}, src)
     cconv_dst = Base.cconvert(Ptr{UInt8}, dst)
@@ -340,7 +340,7 @@ function try_encode!(e::LZ4HDF5EncodeOptions, dst::AbstractVector{UInt8}, src::A
         dst_p += 4
         while src_left > 0
             if dst_left < 5
-                return nothing
+                return NOT_SIZE
             end
             local b_size = min(src_left, block_size)%Int32
             @assert !iszero(b_size)
@@ -353,7 +353,7 @@ function try_encode!(e::LZ4HDF5EncodeOptions, dst::AbstractVector{UInt8}, src::A
             # but it might be large enough for a copy.
             local c_size = if ret ≥ b_size || iszero(ret)
                 if dst_left < b_size
-                    return nothing
+                    return NOT_SIZE
                 end
                 @static if VERSION ≥ v"1.10"
                     Libc.memcpy(dst_p, src_p, b_size)

--- a/LibLz4/test/hdf5.jl
+++ b/LibLz4/test/hdf5.jl
@@ -51,7 +51,7 @@ end
     # less than 12 bytes
     @test_throws LZ4DecodingError("unexpected end of input") try_find_decoded_size(d, UInt8[])
     @test_throws LZ4DecodingError("decoded size is negative") try_find_decoded_size(d, fill(0xFF,12))
-    @test typemax(Int64) == Int64(try_find_decoded_size(d, [0x7F; fill(0xFF, 11);]))
+    @test typemax(Int64) == try_find_decoded_size(d, [0x7F; fill(0xFF, 11);])
     # invalid block size
     @test_throws LZ4DecodingError("block size must be greater than zero") decode(d, [
         reinterpret(UInt8, [hton(Int64(0))]);

--- a/LibLz4/test/numcodecs.jl
+++ b/LibLz4/test/numcodecs.jl
@@ -1,4 +1,4 @@
-using ChunkCodecCore: encode_bound, decoded_size_range, encode, decode, DecodedSizeError
+using ChunkCodecCore: encode_bound, decoded_size_range, encode, decode, DecodedSizeError, MaybeSize
 using ChunkCodecLibLz4
 using ChunkCodecTests: test_codec
 using Test: @testset, @test_throws, @test
@@ -46,5 +46,5 @@ end
 @testset "max decoded size" begin
     d = LZ4NumcodecsDecodeOptions()
     c = UInt8[0xFF;0xFF;0xFF;0x7F; 0x1F;0x00;0x01;0x00;fill(0xFF,8421504);0x66;0x50;fill(0x00,5)]
-    @test_throws DecodedSizeError(2^24, typemax(Int32)) decode(d, c; max_size=Int64(2)^24)
+    @test_throws DecodedSizeError(2^24, MaybeSize(-typemax(Int32))) decode(d, c; max_size=Int64(2)^24)
 end

--- a/LibSnappy/CHANGELOG.md
+++ b/LibSnappy/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibSnappy-v0.2.1) - 2025-07-28

--- a/LibSnappy/Project.toml
+++ b/LibSnappy/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibSnappy"
 uuid = "eac87354-86d5-4a5b-ab5f-a6ee56b239b3"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 
 [compat]
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 snappy_jll = "1"
 julia = "1.6"
 

--- a/LibSnappy/src/ChunkCodecLibSnappy.jl
+++ b/LibSnappy/src/ChunkCodecLibSnappy.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_in_range,
     check_contiguous,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibSnappy/src/ChunkCodecLibSnappy.jl
+++ b/LibSnappy/src/ChunkCodecLibSnappy.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_in_range,
     check_contiguous,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     try_decode!,

--- a/LibSnappy/src/decode.jl
+++ b/LibSnappy/src/decode.jl
@@ -33,7 +33,7 @@ function SnappyDecodeOptions(;
     SnappyDecodeOptions(codec)
 end
 
-function try_find_decoded_size(::SnappyDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::SnappyDecodeOptions, src::AbstractVector{UInt8})::Int64
     check_contiguous(src)
     nbytes = Ref(Csize_t(0))
     ret = ccall((:snappy_uncompressed_length, libsnappy), Cint,
@@ -56,7 +56,7 @@ function try_decode!(d::SnappyDecodeOptions, dst::AbstractVector{UInt8}, src::Ab
     src_size::Int64 = length(src)
     nbytes::Int64 = try_find_decoded_size(d, src)
     if dst_size < nbytes
-        nothing
+        NOT_SIZE
     else
         uncompressed_length = Ref(Csize_t(nbytes))
         status = ccall((:snappy_uncompress, libsnappy), Cint,

--- a/LibSnappy/src/decode.jl
+++ b/LibSnappy/src/decode.jl
@@ -33,7 +33,7 @@ function SnappyDecodeOptions(;
     SnappyDecodeOptions(codec)
 end
 
-function try_find_decoded_size(::SnappyDecodeOptions, src::AbstractVector{UInt8})::Int64
+function try_find_decoded_size(::SnappyDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     check_contiguous(src)
     nbytes = Ref(Csize_t(0))
     ret = ccall((:snappy_uncompressed_length, libsnappy), Cint,
@@ -49,12 +49,12 @@ function try_find_decoded_size(::SnappyDecodeOptions, src::AbstractVector{UInt8}
     end
 end
 
-function try_decode!(d::SnappyDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::SnappyDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
-    nbytes = try_find_decoded_size(d, src)
+    nbytes::Int64 = try_find_decoded_size(d, src)
     if dst_size < nbytes
         nothing
     else

--- a/LibSnappy/src/encode.jl
+++ b/LibSnappy/src/encode.jl
@@ -42,7 +42,7 @@ function try_encode!(e::SnappyEncodeOptions, dst::AbstractVector{UInt8}, src::Ab
     check_in_range(decoded_size_range(e); src_size)
     ebound = encode_bound(e, src_size)
     if dst_size < ebound
-        return nothing
+        return NOT_SIZE
     end
     compressed_length = Ref(Csize_t(ebound))
     status = ccall((:snappy_compress, libsnappy), Cint,

--- a/LibSnappy/src/encode.jl
+++ b/LibSnappy/src/encode.jl
@@ -34,7 +34,7 @@ function encode_bound(e::SnappyEncodeOptions, src_size::Int64)::Int64
     end
 end
 
-function try_encode!(e::SnappyEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::SnappyEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/LibZlib/CHANGELOG.md
+++ b/LibZlib/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZlib-v0.2.1) - 2025-07-28

--- a/LibZlib/Project.toml
+++ b/LibZlib/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibZlib"
 uuid = "4c0bbee4-addc-4d73-81a0-b6caacae83c8"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 Zlib_jll = "1"
 julia = "1.6"
 

--- a/LibZlib/src/ChunkCodecLibZlib.jl
+++ b/LibZlib/src/ChunkCodecLibZlib.jl
@@ -9,7 +9,8 @@ using ChunkCodecCore:
     check_contiguous,
     check_in_range,
     grow_dst!,
-    DecodingError
+    DecodingError,
+    MaybeSize
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibZlib/src/ChunkCodecLibZlib.jl
+++ b/LibZlib/src/ChunkCodecLibZlib.jl
@@ -10,7 +10,8 @@ using ChunkCodecCore:
     check_in_range,
     grow_dst!,
     DecodingError,
-    MaybeSize
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     decode_options,
     can_concatenate,

--- a/LibZlib/src/decode.jl
+++ b/LibZlib/src/decode.jl
@@ -84,14 +84,14 @@ const _AllDecodeOptions = Union{ZlibDecodeOptions, DeflateDecodeOptions, GzipDec
 
 is_thread_safe(::_AllDecodeOptions) = true
 
-function try_find_decoded_size(::_AllDecodeOptions, src::AbstractVector{UInt8})::Nothing
+function try_find_decoded_size(::_AllDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     nothing
 end
-function try_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     try_resize_decode!(d, dst, src, Int64(length(dst)))
 end
 
-function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::Union{Nothing, Int64}
+function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}, max_size::Int64; kwargs...)::MaybeSize
     dst_size::Int64 = length(dst)
     src_size::Int64 = length(src)
     src_left::Int64 = src_size

--- a/LibZlib/src/decode.jl
+++ b/LibZlib/src/decode.jl
@@ -84,7 +84,7 @@ const _AllDecodeOptions = Union{ZlibDecodeOptions, DeflateDecodeOptions, GzipDec
 
 is_thread_safe(::_AllDecodeOptions) = true
 
-function try_find_decoded_size(::_AllDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::_AllDecodeOptions, src::AbstractVector{UInt8})::Nothing
     nothing
 end
 function try_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
@@ -150,7 +150,7 @@ function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, sr
                         elseif iszero(dst_left) # needs more output
                             local next_size = grow_dst!(dst, max_size)
                             if isnothing(next_size)
-                                return nothing
+                                return NOT_SIZE
                             end
                             dst_left += next_size - dst_size
                             dst_size = next_size

--- a/LibZlib/src/encode.jl
+++ b/LibZlib/src/encode.jl
@@ -125,7 +125,7 @@ _max_decoded_size(::GzipEncodeOptions)::Int64 = 0x7ff60087fa602c66
 
 decoded_size_range(e::_AllEncodeOptions) = Int64(0):Int64(1):_max_decoded_size(e)
 
-function try_encode!(e::_AllEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::_AllEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     # -15: deflate, 15: zlib, 15+16: gzip
     # smaller windowBits might break encode bound
     windowBits = _windowBits(e.codec)

--- a/LibZlib/src/encode.jl
+++ b/LibZlib/src/encode.jl
@@ -136,7 +136,7 @@ function try_encode!(e::_AllEncodeOptions, dst::AbstractVector{UInt8}, src::Abst
     dst_size::Int64 = length(dst)
     check_in_range(decoded_size_range(e); src_size)
     if iszero(dst_size)
-        return nothing
+        return NOT_SIZE
     end
     stream = ZStream()
     deflateInit2(stream, e.level, windowBits)
@@ -187,7 +187,7 @@ function try_encode!(e::_AllEncodeOptions, dst::AbstractVector{UInt8}, src::Abst
                 end
                 if iszero(dst_left)
                     # no more space, but not Z_STREAM_END
-                    return nothing
+                    return NOT_SIZE
                 end
                 @assert ret == Z_OK
             end

--- a/LibZstd/CHANGELOG.md
+++ b/LibZstd/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72)
 - Added support for Julia 1.6 [#68](https://github.com/JuliaIO/ChunkCodecs.jl/pull/68)
 
 ## [v0.2.1](https://github.com/JuliaIO/ChunkCodecs.jl/tree/LibZstd-v0.2.1) - 2025-07-28

--- a/LibZstd/Project.toml
+++ b/LibZstd/Project.toml
@@ -1,14 +1,14 @@
 name = "ChunkCodecLibZstd"
 uuid = "55437552-ac27-4d47-9aa3-63184e8fd398"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.2.1"
+version = "0.3.0-dev"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 
 [compat]
-ChunkCodecCore = "0.5"
+ChunkCodecCore = "0.6"
 Zstd_jll = "1.5.6"
 julia = "1.6"
 

--- a/LibZstd/src/ChunkCodecLibZstd.jl
+++ b/LibZstd/src/ChunkCodecLibZstd.jl
@@ -8,7 +8,8 @@ using ChunkCodecCore:
     DecodeOptions,
     check_contiguous,
     check_in_range,
-    DecodingError
+    DecodingError,
+    MaybeSize
 
 import ChunkCodecCore:
     can_concatenate,

--- a/LibZstd/src/ChunkCodecLibZstd.jl
+++ b/LibZstd/src/ChunkCodecLibZstd.jl
@@ -9,8 +9,8 @@ using ChunkCodecCore:
     check_contiguous,
     check_in_range,
     DecodingError,
-    MaybeSize
-
+    MaybeSize,
+    NOT_SIZE
 import ChunkCodecCore:
     can_concatenate,
     try_decode!,

--- a/LibZstd/src/decode.jl
+++ b/LibZstd/src/decode.jl
@@ -53,7 +53,7 @@ is_thread_safe(::ZstdDecodeOptions) = true
 # find_decompressed_size is modified from CodecZstd.jl
 # https://github.com/JuliaIO/CodecZstd.jl/blob/2f7d084b8b157d83ed85e9d15105f0a708038e45/src/libzstd.jl#L157C1-L215C4
 # From mkitti's PR https://github.com/JuliaIO/CodecZstd.jl/pull/63
-function try_find_decoded_size(::ZstdDecodeOptions, src::AbstractVector{UInt8})::Union{Nothing, Int64}
+function try_find_decoded_size(::ZstdDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
     check_contiguous(src)
     srcSize::Int64 = length(src)
     frameOffset::Int64 = 0
@@ -98,7 +98,7 @@ function try_find_decoded_size(::ZstdDecodeOptions, src::AbstractVector{UInt8}):
     return decompressedSize
 end
 
-function try_decode!(d::ZstdDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_decode!(d::ZstdDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     if isempty(src)

--- a/LibZstd/src/decode.jl
+++ b/LibZstd/src/decode.jl
@@ -53,7 +53,7 @@ is_thread_safe(::ZstdDecodeOptions) = true
 # find_decompressed_size is modified from CodecZstd.jl
 # https://github.com/JuliaIO/CodecZstd.jl/blob/2f7d084b8b157d83ed85e9d15105f0a708038e45/src/libzstd.jl#L157C1-L215C4
 # From mkitti's PR https://github.com/JuliaIO/CodecZstd.jl/pull/63
-function try_find_decoded_size(::ZstdDecodeOptions, src::AbstractVector{UInt8})::MaybeSize
+function try_find_decoded_size(::ZstdDecodeOptions, src::AbstractVector{UInt8})::Union{Nothing, Int64}
     check_contiguous(src)
     srcSize::Int64 = length(src)
     frameOffset::Int64 = 0
@@ -122,7 +122,7 @@ function try_decode!(d::ZstdDecodeOptions, dst::AbstractVector{UInt8}, src::Abst
         if ZSTD_isError(ret)
             err_code = ZSTD_getErrorCode(ret)
             if err_code == Integer(ZSTD_error_dstSize_tooSmall)
-                return nothing
+                return NOT_SIZE
             elseif err_code == Integer(ZSTD_error_memory_allocation)
                 throw(OutOfMemoryError())
             else

--- a/LibZstd/src/encode.jl
+++ b/LibZstd/src/encode.jl
@@ -103,7 +103,7 @@ function try_encode!(e::ZstdEncodeOptions, dst::AbstractVector{UInt8}, src::Abst
         if ZSTD_isError(ret)
             err_code = ZSTD_getErrorCode(ret)
             if err_code == Integer(ZSTD_error_dstSize_tooSmall)
-                return nothing
+                return NOT_SIZE
             elseif err_code == Integer(ZSTD_error_memory_allocation)
                 throw(OutOfMemoryError())
             else

--- a/LibZstd/src/encode.jl
+++ b/LibZstd/src/encode.jl
@@ -73,7 +73,7 @@ function encode_bound(::ZstdEncodeOptions, src_size::Int64)::Int64
     clamp(widen(src_size) + widen(src_size>>8 + margin), Int64)
 end
 
-function try_encode!(e::ZstdEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
+function try_encode!(e::ZstdEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::MaybeSize
     check_contiguous(dst)
     check_contiguous(src)
     src_size::Int64 = length(src)

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -2,7 +2,10 @@ using JET
 using Test
 
 codec_packages = [
-    :ChunkCodecLibBlosc,
+    :ChunkCodecCore,
+    :ChunkCodecBitshuffle,
+    :ChunkCodecLibAec,
+    # :ChunkCodecLibBlosc,
     :ChunkCodecLibBrotli,
     :ChunkCodecLibBzip2,
     :ChunkCodecLibLz4,


### PR DESCRIPTION
This PR changes the return type of `try_encode!`, `try_decode!`, and `try_resize_decode!` from `Union{Nothing, Int64}` to a new `MaybeSize` type. This new type is a simple wrapper of an `Int64` where negative values represent not enough dst space, and positive or zero values represent regular integers.

`MaybeSize` supports converting to and from `Int64` and will throw `InexactError` if a negative value is converted to an `Int64`, or a negative `Int64` is converted to a `MaybeSize`.

There is a added constant `NOT_SIZE = MaybeSize(typemin(Int64))`

Aside from `typemin(Int64)`, the other negative values can be used as a size hint, to improve error messages or performance.

For example:

```julia
using ChunkCodecLibLz4
using Chairmarks
u = zeros(UInt8, 2^24);
c = encode(LZ4BlockEncodeOptions(), u);
@b decode(LZ4BlockCodec(), c)
```

main: 4.907 ms (30 allocs: 36.358 MiB, 8.26% gc time)
PR: 2.359 ms (3 allocs: 16.000 MiB)