### PR TITLE
[LibZlib] clean up redundant `can_concatenate`

### DIFF
--- a/LibZlib/src/ChunkCodecLibZlib.jl
+++ b/LibZlib/src/ChunkCodecLibZlib.jl
@@ -92,8 +92,6 @@ decode_options(::GzipCodec) = GzipDecodeOptions()
 # windowBits setting for the codec
 _windowBits(::GzipCodec) = Cint(15+16)
 
-can_concatenate(::GzipCodec) = true
-
 include("encode.jl")
 include("decode.jl")
 


### PR DESCRIPTION
This is covered by the fallback, so this is redundant.