### PR TITLE
[ChunkCodecTests] Fix for `test_encoder_decoder` resizing.

### DIFF
--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [v0.1.7](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.7) - 2025-08-28
+
 - Fix for `test_encoder_decoder` resizing. [#75](https://github.com/JuliaIO/ChunkCodecs.jl/pull/75)
 
 ## [v0.1.6](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.6) - 2025-08-26

--- a/ChunkCodecTests/CHANGELOG.md
+++ b/ChunkCodecTests/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix for `test_encoder_decoder` resizing. [#75](https://github.com/JuliaIO/ChunkCodecs.jl/pull/75)
+
 ## [v0.1.6](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecTests-v0.1.6) - 2025-08-26
 
 - Update to `ChunkCodecCore` 0.6 [#72](https://github.com/JuliaIO/ChunkCodecs.jl/pull/72) [#73](https://github.com/JuliaIO/ChunkCodecs.jl/pull/73)

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecTests"
 uuid = "06b1ce50-b741-4199-b118-ba5fe1a70fa7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -126,7 +126,7 @@ function test_encoder_decoder(e, d; trials=100)
         dst = view(dst_buffer, 1:s+1)
         @test try_resize_decode!(d, dst, encoded, s-1) === MaybeSize(s)
         @test try_resize_decode!(d, dst, encoded, s) === MaybeSize(s)
-        @test try_resize_decode!(d, dst, encoded, s+2) === MaybeSize(s)
+        @test try_resize_decode!(d, dst, encoded, s+1) === MaybeSize(s)
         @test length(dst) == s + 1
         @test dst[1:s] == data
         @test dst_buffer[end] == 0x00


### PR DESCRIPTION
Before this fix, `test_encoder_decoder` could try to resize a view because the `max_size` in a test call to `try_resize_decode!` was larger than the `dst` size.