### PR TITLE
[ChunkCodecCore] Bump to version 1.0.0

### DIFF
--- a/Bitshuffle/Project.toml
+++ b/Bitshuffle/Project.toml
@@ -7,7 +7,7 @@ version = "0.2.0"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 julia = "1.6"
 
 [workspace]

--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [v1.0.0](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v1.0.0) - 2025-08-29
+
+### The API is now stable
+No breaking changes.
+
 ## [v0.6.0](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v0.6.0) - 2025-08-26
 
 ### BREAKING `can_concatenate` is now a decoder method instead of a `Codec` method [#73](https://github.com/JuliaIO/ChunkCodecs.jl/pull/73)

--- a/ChunkCodecCore/Project.toml
+++ b/ChunkCodecCore/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkCodecCore"
 uuid = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.6.0"
+version = "1.0.0"
 
 [compat]
 julia = "1.6"

--- a/ChunkCodecCore/README.md
+++ b/ChunkCodecCore/README.md
@@ -1,7 +1,5 @@
 # ChunkCodecCore
 
-## Warning: ChunkCodecCore is currently a WIP and its API may drastically change at any time.
-
 A consistent Julia interface for lossless encoding and decoding of bytes in memory.
 
 This package defines the ChunkCodec interface and implements a noop and byte shuffle encoder and decoder.

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -8,6 +8,6 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 Test = "1"
 julia = "1.6"

--- a/LibAec/Project.toml
+++ b/LibAec/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 libaec_jll = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 libaec_jll = "1"
 julia = "1.6"
 

--- a/LibBlosc/Project.toml
+++ b/LibBlosc/Project.toml
@@ -9,7 +9,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
 Blosc_jll = "1"
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 julia = "1.6"
 
 [workspace]

--- a/LibBrotli/Project.toml
+++ b/LibBrotli/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 brotli_jll = "4611771a-a7d2-5e23-8d00-b1becdba1aae"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 brotli_jll = "1"
 julia = "1.6"
 

--- a/LibBzip2/Project.toml
+++ b/LibBzip2/Project.toml
@@ -9,7 +9,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 
 [compat]
 Bzip2_jll = "1"
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 julia = "1.6"
 
 [workspace]

--- a/LibLz4/Project.toml
+++ b/LibLz4/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Lz4_jll = "5ced341a-0733-55b8-9ab6-a4889d929147"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 Lz4_jll = "1"
 julia = "1.6"
 

--- a/LibSnappy/Project.toml
+++ b/LibSnappy/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 snappy_jll = "1"
 julia = "1.6"
 

--- a/LibZlib/Project.toml
+++ b/LibZlib/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 Zlib_jll = "1"
 julia = "1.6"
 

--- a/LibZstd/Project.toml
+++ b/LibZstd/Project.toml
@@ -8,7 +8,7 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 
 [compat]
-ChunkCodecCore = "0.6"
+ChunkCodecCore = "0.6, 1"
 Zstd_jll = "1.5.6"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# ChunkCodecs (WIP)
+# ChunkCodecs
 
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
-
-## Warning: ChunkCodecs is currently a WIP. Suggestions for major API changes are welcome.
 
 A consistent Julia interface for lossless encoding and decoding of bytes in memory.
 


### PR DESCRIPTION
This PR marks the ChunkCodecCore API as stable.