### PR TITLE
[ChunkCodecCore] Check `Base.elsize` in `check_contiguous`

### DIFF
--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added check for `Base.elsize` in `check_contiguous`. [#84](https://github.com/JuliaIO/ChunkCodecs.jl/pull/84)
+
 ## [v1.0.0](https://github.com/JuliaIO/ChunkCodecs.jl/tree/ChunkCodecCore-v1.0.0) - 2025-08-29
 
 ### The API is now stable

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -286,6 +286,7 @@ function check_contiguous(x::AbstractVector{UInt8})
     y = Base.cconvert(Ptr{UInt8}, x)
     GC.@preserve y Base.unsafe_convert(Ptr{UInt8}, y)
     isone(only(strides(x))) || throw(ArgumentError("vector is not contiguous in memory"))
+    isone(Base.elsize(typeof(x))) || throw(ArgumentError("vector is not contiguous in memory"))
     Int64(length(x))
     @assert !signbit(length(x))
     nothing


### PR DESCRIPTION
This PR adds a check to `check_contiguous` that `Base.elsize` is one. This checks the vector supports `Base.elsize` and doesn't have any padding between bytes.

Ref: https://github.com/JuliaPy/PythonCall.jl/issues/579 https://github.com/JuliaLang/julia/pull/59466